### PR TITLE
differentiate starting and building

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A native app for JupyterLab, based on electron.",
   "main": "node_index.ts",
   "scripts": {
-    "start": "npm run build && electron .",
+    "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack"
+    "build": "webpack",
+    "build:all": "npm run build && npm start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Follow up to #7 

I agree that we should have a command that lets you build all the source files and start the electron process but I also like to be able to just start the electron process with a separate command without running webpack. 

Now if you run `npm run build:all` it will compile all the source and  start the electron process. 