### PR TITLE
remove application-extension dependenices

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@jupyterlab/about-extension": "^0.5.0",
-    "@jupyterlab/application-extension": "^0.5.0",
     "@jupyterlab/apputils-extension": "^0.5.0",
     "@jupyterlab/codemirror-extension": "^0.5.0",
     "@jupyterlab/completer-extension": "^0.5.1",
@@ -66,7 +65,6 @@
   "jupyterlab": {
     "extensions": [
       "@jupyterlab/about-extension",
-      "@jupyterlab/application-extension",
       "@jupyterlab/apputils-extension",
       "@jupyterlab/codemirror-extension",
       "@jupyterlab/completer-extension",


### PR DESCRIPTION
Partially addresses #8 

Removes the extensions so that  JupyterLab's `onbeforeunload` does not interfere with electron's