### PR TITLE
Improve build so compiled Javascript files aren't stored with the source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "jupyterlab_app",
   "version": "0.0.1",
   "description": "A native app for JupyterLab, based on electron.",
-  "main": "src/main/main.js",
+  "main": "build/lib/main/main.js",
   "scripts": {
     "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "rm -fr build",
     "build": "tsc && webpack",
     "build:all": "npm run build && npm start"
   },

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -21,12 +21,12 @@ Distributed under the terms of the Modified BSD License.
     "appName": "JupyterLab",
     "baseUrl": "http://localhost:8888/",
     "wsUrl": "",
-    "publicUrl": "../../build/",
+    "publicUrl": "../../build",
     "token": "{{ token }}"
   }</script>
 
   <script>
-    require('../../build/main.bundle.js');
+    require('../../main.bundle.js');
   </script>
 
   <script type="text/javascript" src="http://localhost:8888/static/components/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full,Safe&amp;delayStartupUntil=configured" charset="utf-8"></script>

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -26,6 +26,7 @@ function main() : void {
     // Require Extensions 
     for (let ext of JupyterLab.extensions){
         try {
+            console.log(ext);
             lab.registerPluginModule(ext);
         } catch (e) {
             console.error(e);

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -100,7 +100,7 @@ export class JupyterApplication {
     /**
      * The JupyterLab window
      */
-    private mainWindow: any;
+    private mainWindow: Electron.BrowserWindow;
 
     /**
      * The file that stores index.html after it has been
@@ -195,7 +195,7 @@ export class JupyterApplication {
         this.server.start(8888)
             .then((serverData) => {
                 console.log("Jupyter Server started at: " + serverData.url + "?token=" + serverData.token);
-                let source = fs.readFileSync(path.join(__dirname, '../browser/index.html')).toString();
+                let source = fs.readFileSync(path.join(__dirname, '../../../src/browser/index.html')).toString();
                 let template = Handlebars.compile(source);
                 let html = template(serverData);
                 fs.writeFileSync(path.resolve(__dirname, this.indexFile), html);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "lib": ["ES5", "ES2015.Collection", "ES2015.Promise", "DOM"],
+    "outDir": "./build/lib",
     "baseUrl": "."
   },
   "include": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,12 +3,7 @@ var path = require('path');
 var fs = require('fs-extra');
 var crypto = require('crypto');
 var package_data = require('./package.json');
-
-// Ensure a clear build directory.
 var buildDir = './build';
-fs.removeSync(buildDir);
-fs.ensureDirSync(buildDir);
-
 
 // Create the hash
 var hash = crypto.createHash('md5');
@@ -18,11 +13,11 @@ fs.writeFileSync(path.resolve(buildDir, 'hash.md5'), digest);
 
 
 module.exports = {
-  entry:  path.resolve(buildDir, '../src/browser/index.js'),
+  entry:  path.resolve(buildDir, 'lib/browser/index.js'),
   output: {
     path: path.resolve(buildDir),
     filename: '[name].bundle.js',
-    publicPath: '../../build/'
+    publicPath: '../../'
   },
   module: {
     rules: [


### PR DESCRIPTION
I reconfigured the typescript compiler to store all compiled files in the build directory instead of in the same directory as their source files. This makes development much nicer.