### PR TITLE
Update splash to repeat and fade at end of an iteration

### DIFF
--- a/src/browser/css/main.css
+++ b/src/browser/css/main.css
@@ -26,7 +26,6 @@ table { border-collapse: collapse; border-spacing: 0; }
 
 
 #universe {
-    animation: fade .4s linear 2.5s forwards;
     z-index: 1;
     position: absolute;
     overflow: hidden;
@@ -63,7 +62,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 }
 
 #moon1.orbit {
-    animation: orbit 2s ease .5s;
+    animation: orbit 3.5s ease -1.0s infinite;
     width: 200px;
     height: 140px;
     margin-top: -53px;
@@ -71,7 +70,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 }
 
 #moon2.orbit {
-    animation: orbit 2s ease .5s;
+    animation: orbit 3.5s ease -1.0s infinite;
     width: 132px;
     height: 180px;
     margin-top: -66px;
@@ -81,7 +80,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 #moon3.orbit {
     display: flex;
     align-items: flex-end;
-    animation: orbit 2s ease .5s;
+    animation: orbit 3.5s ease -1.0s infinite;
     width: 220px;
     height: 166px;
     margin-top: -96px;
@@ -152,21 +151,21 @@ table { border-collapse: collapse; border-spacing: 0; }
 @keyframes sk-rotate { 100% { transform: rotate(360deg); -webkit-transform: rotate(360deg) }}
 
 @-webkit-keyframes sk-bounce {
-  0%, 100% { -webkit-transform: scale(0.0) }
-  50% { -webkit-transform: scale(1.0) }
+  0%, 50%, 100% { -webkit-transform: scale(0.0) }
+  75% { -webkit-transform: scale(1.0) }
 }
 
 @keyframes sk-bounce {
-  0%, 100% { 
+  0%, 50%, 100% { 
     transform: scale(0.0);
     -webkit-transform: scale(0.0);
-  } 50% { 
+  } 75% { 
     transform: scale(1.0);
     -webkit-transform: scale(1.0);
   }
 }
 @keyframes orbit {
-    0% {
+    0%, 50% {
         transform: rotateZ(0deg);
     }
     100% {
@@ -175,7 +174,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 }
 
 @keyframes orbit2 {
-    0% {
+    0%, 50% {
         transform: rotateZ(0deg);
     }
     100% {

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -17,7 +17,7 @@ Distributed under the terms of the Modified BSD License.
 }
   </style>
   <meta charset="utf-8">
-  <link rel="stylesheet" href="../../../src/browser/css/main.css" type="text/css">
+  <link rel="stylesheet" href="../../src/browser/css/main.css" type="text/css">
 
   <title>JupyterLab Application</title>
 
@@ -37,7 +37,7 @@ Distributed under the terms of the Modified BSD License.
   }</script>
 
   <script>
-    require('../../main.bundle.js');
+    require('../../build/main.bundle.js');
   </script>
 
    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
@@ -45,20 +45,20 @@ Distributed under the terms of the Modified BSD License.
 </head>
 
 <body>
-  <div id="universe">
-    <div id="galaxy">
+    <div id="universe">
+        <div id="galaxy">
         <div id="main-logo">
         </div>
-          <div id="moon1" class="moon orbit">
-              <div class="planet"></div>
-          </div>
-          <div id="moon2" class="moon orbit">
-              <div class="planet"></div>
-          </div>
-          <div id="moon3" class="moon orbit">
-              <div class="planet"></div>
-          </div>
-      </div>
+            <div id="moon1" class="moon orbit">
+                <div class="planet"></div>
+            </div>
+            <div id="moon2" class="moon orbit">
+                <div class="planet"></div>
+            </div>
+            <div id="moon3" class="moon orbit">
+                <div class="planet"></div>
+            </div>
+        </div>
     </div>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prefixfree/1.0.7/prefixfree.min.js"></script>
 </body>

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -47,6 +47,14 @@ function main() : void {
         version = version.slice(1);
     }
 
+    // Promise for animation listener
+    let promise : Promise<string>;
+    document.getElementById('moon1').addEventListener('animationiteration', () => {
+        promise.then( (animation) => {
+            document.getElementById('universe').style.animation = animation;
+        })
+    });
+
 
     let lab = new app({
         namespace: namespace,
@@ -72,13 +80,22 @@ function main() : void {
         // No-op
     }
 
+    // Get token from server
     ipcRenderer.send("ready-for-token");
     ipcRenderer.on("token", (event: any, arg: any) => {
+        // Set token
         PageConfig.setOption("token", arg);
-        lab.start({ "ignorePlugins": ignorePlugins });
-        // document.getElementById("universe").style.animation = "fade .4s linear 0s forwards";
+        // Start lab and fade splash
+        promise = new Promise((resolve, reject) => {
+            try{
+                lab.start({ "ignorePlugins": ignorePlugins });
+                resolve("fade .4s linear 0s forwards");
+            }
+            catch (e){
+                reject(e);
+            }
+        });
     });
-
 }
 
 window.onload = main;

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -2,10 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { dialog, app, BrowserWindow, ipcMain } from 'electron'
-import { ChildProcess, spawn } from 'child_process';
-// import * as Handlebars from 'handlebars';
-import * as fs from 'fs';
-import * as path from 'path';
+import { ChildProcess, spawn } from 'child_process'
+import * as path from 'path'
 import * as url from 'url'
 
 class JupyterServer {
@@ -103,20 +101,11 @@ export class JupyterApplication {
     private mainWindow: Electron.BrowserWindow;
 
     /**
-     * The file that stores index.html after it has been
-     * run through the templater. This is a hack that should
-     * be replaced when the JupyterLab application api is 
-     * updated.
-     */
-    private indexFile: string;
-
-    /**
      * Construct the Jupyter application
      */
     constructor() {
         this.registerListeners();
         this.server = new JupyterServer();
-        this.indexFile = path.join(__dirname, 'temp.index.html');
     }
 
     /**
@@ -142,7 +131,6 @@ export class JupyterApplication {
 
         app.on('quit', () => {
             this.server.stop();
-            fs.unlinkSync(this.indexFile);
         });
     }
 
@@ -161,7 +149,7 @@ export class JupyterApplication {
         });
 
         this.mainWindow.loadURL(url.format({
-            pathname: this.indexFile,
+            pathname: path.resolve(__dirname, '../../../src/browser/index.html'),
             protocol: 'file:',
             slashes: true
         }));
@@ -201,8 +189,6 @@ export class JupyterApplication {
      */
     public start(): void {
         let token: Promise<string>;
-        let source = fs.readFileSync(path.join(__dirname, '../../../src/browser/index.html')).toString();
-        fs.writeFileSync(path.resolve(__dirname, this.indexFile), source);
         
         ipcMain.on("ready-for-token", (event: any, arg: any) => {
             token.then((data) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
   output: {
     path: path.resolve(buildDir),
     filename: '[name].bundle.js',
-    publicPath: '../../'
+    publicPath: '../../build/'
   },
   module: {
     rules: [


### PR DESCRIPTION
The splash screen fade was previously hardcoded into the CSS. This fades the splash screen in "index.ts" once the app is loaded and the animation reaches the end of an iteration. The CSS was adjusted to add a delay at the beginning of an iteration. 