### PR TITLE
Start app on the server it created

### DIFF
--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -30,7 +30,6 @@ Distributed under the terms of the Modified BSD License.
     "assetsDir": "",
     "appNamespace": "",
     "appName": "JupyterLab",
-    "baseUrl": "http://localhost:8888/",
     "wsUrl": "",
     "publicUrl": "../../build",
     "token": "{{ token }}"

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -81,10 +81,12 @@ function main() : void {
     }
 
     // Get token from server
-    ipcRenderer.send("ready-for-token");
-    ipcRenderer.on("token", (event: any, arg: any) => {
+    ipcRenderer.send("server-data-ready");
+    ipcRenderer.on("server-data", (event: any, data: any) => {
         // Set token
-        PageConfig.setOption("token", arg);
+        PageConfig.setOption("token", data.token);
+        // Set baseUrl
+        PageConfig.setOption("baseUrl", data.baseUrl);
         // Start lab and fade splash
         promise = new Promise((resolve, reject) => {
             try{

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -11,40 +11,19 @@ class JupyterServer {
      * The child process object for the Jupyter server
      */
     private nbServer: ChildProcess;
-
-    /**
-     * The Jupyter server authentication token
-     */
-    public token: string;
-
-    /**
-     * The Jupyter server hostname
-     */
-    public hostname: string;
-
-    /**
-     * The Jupyter server port number
-     */
-    public port: number;
-
-    /**
-     * The Jupyter server url
-     */
-    public url: string;
-
-    /**
-     * The jupyter server notebook directory
-     */
-    public notebookDir: string;
     
     /**
      * Start a local Jupyer server on the specified port. Returns
      * a promise that is fulfilled when the Jupyter server has
      * started and all the required data (url, token, etc.) is
-     * collected. This data is collected using `jupyter notebook list`
+     * collected. This data is collected from the data written to
+     * std out upon sever creation
      */
     public start(port: number): Promise<any> {
         return new Promise((resolve, reject) => {
+            let urlRegExp = /http:\/\/localhost:\d+\/\?token=\w+/g;
+            let tokenRegExp = /token=\w+/g;
+            let baseRegExp = /http:\/\/localhost:\d+\//g;
             this.nbServer = spawn('jupyter', ['notebook', '--no-browser', '--port', String(port)]);
 
             this.nbServer.on('error', (err: Error) => {
@@ -52,30 +31,22 @@ class JupyterServer {
                 reject(err);
             });
 
-            this.nbServer.stderr.on('data', (serverData: string) => {
-                if (serverData.indexOf("The Jupyter Notebook is running at") == -1)
-                    return;
-                this.nbServer.removeAllListeners();
-                this.nbServer.stderr.removeAllListeners();
-                
-                /* Get server data */
-                let list = spawn('jupyter', ['notebook', 'list', '--json']);
+            this.nbServer.stderr.on('data', (serverBuff: string) => {
+                let urlMatch = serverBuff.toString().match(urlRegExp);
+                if (!urlMatch){ 
+                    return; 
+                }
+                else{
+                    let url = urlMatch[0].toString();
+                    this.nbServer.removeAllListeners();
+                    this.nbServer.stderr.removeAllListeners();
 
-                list.on('error', (err: Error) => {
-                    list.stdout.removeAllListeners();
-                    reject(err);
-                });
-
-                list.stdout.on('data', (data: string) => {
-                    let serverData = JSON.parse(data);
-                    serverData.port = Number(serverData.port);
-                    this.token = serverData.token;
-                    this.hostname = serverData.hostname;
-                    this.port = serverData.port;
-                    this.url = serverData.url;
-                    this.notebookDir = serverData.notebook_dir;
+                    let serverData = {
+                        token: (url.match(tokenRegExp))[0].replace("token=", ""),
+                        baseUrl: (url.match(baseRegExp))[0]
+                    }
                     resolve(serverData);
-                });
+                }
             });
         });
     }
@@ -182,17 +153,15 @@ export class JupyterApplication {
 
     /**
      * Starts the Jupyter Server and launches the electron application.
-     * When the Jupyter Sevrer start promise is fulfilled, the Handlebars
-     * templater is run on index.html and the output is saved to a file.
-     * The electron render process is then started on that file by
-     * calling createWindow
+     * When the Jupyter Sevrer start promise is fulfilled, the baseUrl
+     * and the token is send to the browser window.
      */
     public start(): void {
         let token: Promise<string>;
         
-        ipcMain.on("ready-for-token", (event: any, arg: any) => {
+        ipcMain.on("server-data-ready", (event: any, arg: any) => {
             token.then((data) => {
-                event.sender.send("token", data);
+                event.sender.send("server-data", data);
             });
         });
         this.createWindow();
@@ -200,8 +169,8 @@ export class JupyterApplication {
         token = new Promise((resolve, reject) => {
             this.server.start(8888)
             .then((serverData) => {
-                console.log("Jupyter Server started at: " + serverData.url + "?token=" + serverData.token);
-                resolve(serverData.token);
+                console.log("Jupyter Server started at: " + serverData.baseUrl + "?token=" + serverData.token);
+                resolve(serverData);
 
             })
             .catch((err) => {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -33,20 +33,18 @@ class JupyterServer {
 
             this.nbServer.stderr.on('data', (serverBuff: string) => {
                 let urlMatch = serverBuff.toString().match(urlRegExp);
-                if (!urlMatch){ 
+                if (!urlMatch)
                     return; 
-                }
-                else{
-                    let url = urlMatch[0].toString();
-                    this.nbServer.removeAllListeners();
-                    this.nbServer.stderr.removeAllListeners();
 
-                    let serverData = {
-                        token: (url.match(tokenRegExp))[0].replace("token=", ""),
-                        baseUrl: (url.match(baseRegExp))[0]
-                    }
-                    resolve(serverData);
+                let url = urlMatch[0].toString();
+                this.nbServer.removeAllListeners();
+                this.nbServer.stderr.removeAllListeners();
+
+                let serverData = {
+                    token: (url.match(tokenRegExp))[0].replace("token=", ""),
+                    baseUrl: (url.match(baseRegExp))[0]
                 }
+                resolve(serverData);
             });
         });
     }


### PR DESCRIPTION
Instead of using the "jupyter notebook list" method to get server data, this just uses the output that is produced when the server is created. This way we know we are using the server that was created by the program and the application won't crash if multiple servers are running. Both the baseUrl and the token are sent via IPC from the main process to the renderer process. Fixes #13 and #36. 