### PR TITLE
Add debug tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -fr build",
+    "watch:tsc": "tsc -w",
+    "watch:pack": "webpack --progress --colors --watch",
     "build": "tsc && webpack",
     "build:all": "npm run build && npm start"
   },
@@ -21,6 +23,7 @@
   "homepage": "https://github.com/jupyterlab/jupyterlab_app#readme",
   "devDependencies": {
     "css-loader": "^0.27.3",
+    "devtron": "^1.4.0",
     "file-loader": "^0.10.1",
     "fs-extra": "^2.1.2",
     "json-loader": "^0.5.4",
@@ -85,6 +88,7 @@
     "@jupyterlab/tooltip": "^0.7.0",
     "@jupyterlab/tooltip-extension": "^0.7.0",
     "electron": "^1.6.11",
+    "electron-debug": "^1.2.0",
     "es6-promise": "^4.1.0",
     "font-awesome": "^4.6.3"
   },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,12 @@
 import {app} from 'electron'
 import {JupyterApplication} from './app';
 
+/**
+ * Require debugging tools. Only
+ * runs when in development.
+ */
+require('electron-debug')({showDevTools: false});
+
 app.on('ready', () => {
   let jupyterApp = new JupyterApplication();
   jupyterApp.start();


### PR DESCRIPTION
This PR adds the debug packages suggested by @ddavidebor. I also added npm scripts for running the typescript compiler and webpack in watch mode. This fixes issue #41 