### PR TITLE
Store window size at app close so app can be reopened in same state

### DIFF
--- a/src/browser/utils-extension/nativemenu.ts
+++ b/src/browser/utils-extension/nativemenu.ts
@@ -77,7 +77,7 @@ class NativeMenu extends MenuBar implements IMainMenu {
                 nItems[i].type = (items[i].type as 'normal' | 'submenu' | 'separator');
             nItems[i].label = items[i].label;
             nItems[i].command = items[i].command;
-            console.log(items[i].args);
+
             nItems[i].args = items[i].args;
 
             if (items[i].submenu !== null)

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -96,6 +96,7 @@ export class JupyterApplication {
     constructor() {
         this.registerListeners();
         this.server = new JupyterServer();
+        this.mainWindow = new JupyterLabWindow();
         this.menu = new JupyterMainMenu();
     }
 
@@ -115,9 +116,7 @@ export class JupyterApplication {
         // windows open.
         // Need to double check this code to ensure it has expected behaviour
         app.on('activate', () => {
-            if (this.mainWindow === null) {
-                this.createWindow();
-            }
+            this.createWindow();
         });
 
         app.on('quit', () => {
@@ -129,7 +128,8 @@ export class JupyterApplication {
      * Creates the primary application window
      */
     private createWindow(): void {
-        this.mainWindow = new JupyterLabWindow();
+        if (!this.mainWindow.isWindowVisible)
+            this.mainWindow.createWindow();
     }
 
     /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { 
-    dialog, app, BrowserWindow, ipcMain
+    app, ipcMain
 } from 'electron';
 
 import {
@@ -14,11 +14,13 @@ import {
 } from './menu';
 
 import {
+    JupyterLabWindow
+} from './window';
+
+import {
     JupyterAppChannels as Channels
 } from '../ipc';
 
-import * as path from 'path';
-import * as url from 'url';
 
 class JupyterServer {
     /**
@@ -86,7 +88,7 @@ export class JupyterApplication {
     /**
      * The JupyterLab window
      */
-    private mainWindow: Electron.BrowserWindow;
+    private mainWindow: JupyterLabWindow;
 
     /**
      * Construct the Jupyter application
@@ -124,51 +126,11 @@ export class JupyterApplication {
     }
 
     /**
-     * Creates the primary application window and loads the
-     * html
+     * Creates the primary application window
      */
     private createWindow(): void {
-        
-        this.mainWindow = new BrowserWindow({
-            width: 800,
-            height: 600,
-            minWidth: 400,
-            minHeight: 300,
-            show: false,
-            title: 'JupyterLab'
-        });
-
-        this.mainWindow.loadURL(url.format({
-            pathname: path.resolve(__dirname, '../../../src/browser/index.html'),
-            protocol: 'file:',
-            slashes: true
-        }));
-
-        this.mainWindow.webContents.on('did-finish-load', () =>{
-            this.mainWindow.show();
-        });
-
-        // Register dialog on window close
-        this.mainWindow.on('close', (event: Event) => {
-            let buttonClicked = dialog.showMessageBox({
-            type: 'warning',
-            message: 'Do you want to leave?',
-            detail: 'Changes you made may not be saved.',
-            buttons: ['Leave', 'Stay'],
-            defaultId: 0,
-            cancelId: 1
-            });
-            if (buttonClicked === 1) {
-                event.preventDefault();
-            }
-        });
-        
-        this.mainWindow.on('closed', () => {
-            this.mainWindow = null;
-        });
+        this.mainWindow = new JupyterLabWindow();
     }
-
-
 
     /**
      * Starts the Jupyter Server and launches the electron application.

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+    app
+} from 'electron';
+
+import * as fs from 'fs';
+
+export
+namespace UserState {
+    export
+    interface StateIOError {
+
+        type: 'read' | 'write';
+        filename: string;
+        err: any;
+    }
+}
+
+/**
+ * Read and write user data asynchronously.
+ */
+export
+class UserState {
+
+    /**
+     * The path to the platform-specific user data directory.
+     */
+    private path: string = app.getPath('userData');
+
+    /**
+     * The full data file.
+     */
+    private dataFile: string;
+
+    /**
+     * Promise to ensure writing is complete before reading/writing
+     * is iniitated.
+     */
+    private writeInProgress: Promise<any>;
+
+    constructor(private filename: 'string') {
+        this.dataFile = this.path + '/' + this.filename;
+    }
+
+    /**
+     * Check if there is a write in progress.
+     * 
+     * @param cb callback called when writing completes.
+     */
+    private checkWriteInProgress(cb: () => void): void {
+        if (this.writeInProgress) {
+            this.writeInProgress.then((v) => {
+                this.checkWriteInProgress(() => {
+                    this.writeInProgress = null;
+                    cb();
+                });
+            })
+            return;
+        }
+        cb();
+    }
+
+    /**
+     * Write data to the file. Creates promise that is fulfilled when
+     * writing is complete.
+     * 
+     * @param data Javascript object to write to the file as JSON data
+     * @param err_cb 
+     */
+    private doWrite(data: any, err_cb?: (err: UserState.StateIOError) => void): void {
+        this.writeInProgress = new Promise((res, rej) => {
+            fs.writeFile(this.dataFile, JSON.stringify(data), (err) => {
+                if (err && err_cb) {
+                    err_cb({
+                        type: 'write',
+                        filename: this.dataFile,
+                        err: err
+                    });
+                }
+                res({});
+            });
+        });
+    }
+
+    /**
+     * Convert a javascript object to JSON, and write to a file.
+     * 
+     * @param data javascript object to write.
+     * @param err_cb callback called in case of error.
+     */
+    write(data: any, err_cb?: (err: UserState.StateIOError) => void): void {
+        this.checkWriteInProgress(() => {
+            this.doWrite(data, err_cb);
+        });
+    }
+
+    /**
+     * Read json data from a file and parse into
+     * a javascript object.
+     * 
+     * @param cb callback called when data is avaiable.
+     * 
+     * @return a promise that is fullfilled when the data is available
+     */
+    read(): Promise<any> {
+        return new Promise((res, rej) => {
+            this.checkWriteInProgress(() => {
+                fs.readFile(this.dataFile, (err, data) => {
+                    if (err) {
+                        rej({
+                            type: 'read',
+                            filename: this.dataFile,
+                            err: err
+                        });
+                    }
+
+                    let pData: any;
+                    try {
+                        pData = JSON.parse(data.toString())
+                    } catch(err) {
+                        rej({
+                            type: 'read',
+                            filename: this.dataFile,
+                            err: err
+                        });
+                    }
+                    res(pData);
+                });
+        
+            });
+        });
+    }
+}

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -33,7 +33,7 @@ class ApplicationState<T> {
     /**
      * User data
      */
-    state: T;
+    state: T = null;
 
     constructor(private filename: string, state?: T) {
         this.dataFile = this.path + '/' + this.filename;

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -6,7 +6,7 @@ import {
 } from 'electron';
 
 import {
-    UserState
+    ApplicationState
 } from './state';
 
 import * as path from 'path';
@@ -21,7 +21,7 @@ interface WindowState {
 export
 class JupyterLabWindow {
 
-    private windowState = new UserState<WindowState>('jupyter-window-data', {});
+    private windowState = new ApplicationState<WindowState>('jupyter-window-data', {});
 
     private statePromise: Promise<void>;
 
@@ -40,13 +40,12 @@ class JupyterLabWindow {
         this.statePromise = new Promise<void>((res, rej) => {
             this.windowState.read().then(() => {
                 let state = this.windowState.state
-
                 if (state.winBounds)
                     this.window.setBounds(state.winBounds);
                 else
                     this.window.center();
                 res();
-            }).catch(()=>{});
+            }).catch(()=>{ res(); });
         });
 
         this.registerListeners();

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { 
+    dialog, BrowserWindow
+} from 'electron';
+
+import {
+    UserState
+} from './state';
+
+import * as path from 'path';
+import * as url from 'url';
+
+type Rectangle = Electron.Rectangle;
+
+interface WindowState {
+    winBounds?: Rectangle;
+}
+
+export
+class JupyterLabWindow {
+
+    private windowState = new UserState<WindowState>('jupyter-window-data', {});
+
+    private statePromise: Promise<void>;
+
+    private window: Electron.BrowserWindow;
+
+    constructor() {
+        this.window = new BrowserWindow({
+            width: 800,
+            height: 600,
+            minWidth: 400,
+            minHeight: 300,
+            show: false,
+            title: 'JupyterLab'
+        });
+        
+        this.statePromise = new Promise<void>((res, rej) => {
+            this.windowState.read().then(() => {
+                let state = this.windowState.state
+
+                if (state.winBounds)
+                    this.window.setBounds(state.winBounds);
+                else
+                    this.window.center();
+                res();
+            }).catch(()=>{});
+        });
+
+        this.registerListeners();
+
+        this.window.loadURL(url.format({
+            pathname: path.resolve(__dirname, '../../../src/browser/index.html'),
+            protocol: 'file:',
+            slashes: true
+        }));
+    }
+    
+    private updateState() {
+        let bounds = this.window.getBounds();
+        this.windowState.state.winBounds = bounds;
+        this.windowState.write();
+    }
+
+    private registerListeners() {
+        this.window.webContents.on('did-finish-load', () =>{
+            this.statePromise.then(() => {
+                this.window.show();
+            }).catch(()=>{});
+        });
+
+        // Register dialog on window close
+        this.window.on('close', (event: Event) => {
+            /* Save window data */
+            this.updateState();
+
+            let buttonClicked = dialog.showMessageBox({
+            type: 'warning',
+            message: 'Do you want to leave?',
+            detail: 'Changes you made may not be saved.',
+            buttons: ['Leave', 'Stay'],
+            defaultId: 0,
+            cancelId: 1
+            });
+            if (buttonClicked === 1) {
+                event.preventDefault();
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds code to store the position/dimensions of the main window when the user quits the app. This allows recreating the window that was open when the user last quit the app.

To do this, I added some generic code that allows easily storing application state (src/main/state.ts). This code will be useful as we add more features that depend on persistent state.