### PR TITLE
Focus on activate

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -359,7 +359,12 @@ export class JupyterApplication {
         // windows open.
         // Need to double check this code to ensure it has expected behaviour
         app.on('activate', () => {
-            this.createWindow({state: 'local'});
+            if (this.windows.length === 0) {
+                this.createWindow({state: 'local'});
+            }
+            else {
+                this.windows[0].browserWindow.focus();
+            }
         });
 
         app.on('will-quit', (event) => {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { 
-    app, ipcMain, dialog
+    app, ipcMain, dialog, BrowserWindow
 } from 'electron';
 
 import {
@@ -362,7 +362,7 @@ export class JupyterApplication {
             if (this.windows.length === 0) {
                 this.createWindow({state: 'local'});
             }
-            else {
+            else if (BrowserWindow.getFocusedWindow() === null){
                 this.windows[0].browserWindow.focus();
             }
         });


### PR DESCRIPTION
Fixes #76. On activate, only spawn new lab if no windows exist. If a window is in focus, do nothing. Otherwise, focus the first window. 