### PR TITLE
Add keyboard shortcuts without adding to the menubar

### DIFF
--- a/src/browser/extensions/utils-extension/nativemenu.ts
+++ b/src/browser/extensions/utils-extension/nativemenu.ts
@@ -65,13 +65,15 @@ class NativeMenu extends MenuBar implements IMainMenu {
     private buildNativeMenu(menu: Menu): JupyterMenuItemOptions[] {
         let items = menu.items;
         let nItems = new Array<JupyterMenuItemOptions>(items.length);
-        for (let i = 0, n = nItems.length; i < n; i++) {
+        for (let i = 0; i < items.length; i++) {
             nItems[i] = {command: null, type: null, label: null, submenu: null, accelerator: null};
 
-            if (items[i].type == 'command')
+            if (items[i].type == 'command') {
                 nItems[i].type = 'normal';
-            else
+            }
+            else {
                 nItems[i].type = (items[i].type as 'normal' | 'submenu' | 'separator');
+            }
             nItems[i].label = items[i].label;
             nItems[i].command = items[i].command;
             nItems[i].args = items[i].args;

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -35,6 +35,10 @@ import {
     ArrayExt
 } from '@phosphor/algorithm';
 
+import {
+    KeyboardShortcutManager
+} from 'jupyterlab_app/src/main/shortcuts'
+
 
 export
 class JupyterServer {
@@ -292,10 +296,13 @@ export class JupyterApplication {
      */
     private windows: JupyterLabWindow[] = [];
 
+    private shortcutManager: KeyboardShortcutManager;
+
     /**
      * Construct the Jupyter application
      */
     constructor() {
+        this.shortcutManager = new KeyboardShortcutManager(this.windows);
         this.registerListeners();
         this.menu = new JupyterMainMenu();
         this.serverFactory = new JupyterServerFactory();

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -43,7 +43,6 @@ class JupyterMainMenu {
             }));
         }
         Menu.setApplicationMenu(this.menu);
-        this.addEditMenu();
     }
 
     /**
@@ -110,20 +109,5 @@ class JupyterMainMenu {
      */
     private handleClick(menu: Electron.MenuItem, window: Electron.BrowserWindow): void {
         window.webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
-    }
-
-    private addEditMenu(){
-        let edit: Electron.MenuItemConstructorOptions[] = [
-                {role: 'undo'},
-                {role: 'redo'},
-                {type: 'separator'},
-                {role: 'cut'},
-                {role: 'copy'},
-                {role: 'paste'},
-                {role: 'pasteandmatchstyle'},
-                {role: 'delete'},
-                {role: 'selectall'}
-        ];
-        this.addMenu(null, {rank: 2, label: "Edit", submenu: edit});
     }
 }

--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+    app, globalShortcut, webContents
+} from 'electron';
+
+import {
+    JupyterLabWindow
+} from './window';
+
+/**
+ * Interface for keyboard shortcuts recognized by the shortcut manager
+ */
+export interface KeyboardShortcut{
+    accelerator: string,
+    command: () => void
+}
+
+export class KeyboardShortcutManager{
+
+    /**
+     * Whether or not an application window exists and is in focus
+     */
+    private active: boolean;
+
+    /**
+     * All application windows
+     */
+    private windows: JupyterLabWindow[];
+
+    /**
+     * The enabled shortcuts
+     */
+    private shortcuts: KeyboardShortcut[] = [
+        {accelerator: 'CmdOrCtrl+c', command: KeyboardCommands.copy},
+        {accelerator: 'CmdOrCtrl+v', command: KeyboardCommands.paste},
+        {accelerator: 'CmdOrCtrl+x', command: KeyboardCommands.cut},
+        {accelerator: 'CmdOrCtrl+=', command: KeyboardCommands.zoomIn},
+        {accelerator: 'CmdOrCtrl+-', command: KeyboardCommands.zoomOut}
+    ];
+
+    /**
+     * Create a new shortcut manager
+     * 
+     * @param windows - The application windows
+     */
+    constructor(windows: JupyterLabWindow[]){
+        this.windows = windows;
+        app.on('browser-window-focus', (event:Event, window: Electron.BrowserWindow) => {
+            if (!this.active){
+                this.enableShortcuts();
+                this.active = true;
+            }
+        });
+        app.on('browser-window-blur', (event: Event, window: Electron.BrowserWindow) => {
+            if (!this.isAppFocused()){
+                this.disableShortcuts();
+                this.active = false;
+            }
+        });
+        app.on('window-all-closed', () => {
+            this.disableShortcuts();
+        });
+    }
+
+    /**
+     * Enables all shortcuts
+     */
+    private enableShortcuts(){
+        this.shortcuts.forEach( ({accelerator, command}) => {
+            globalShortcut.register(accelerator, command);
+        });
+    }
+
+    /**
+     * Disables all shortcuts
+     */
+    private disableShortcuts(){
+        globalShortcut.unregisterAll();
+    }
+
+    /**
+     * Checks whether or not an application window is in focus
+     * Note: There exists an "isFocused" method on BrowserWindow
+     * objects, but it isn't a reliable indiciator of focus. 
+     */
+    private isAppFocused(): boolean{
+        let visible = false;
+        let focus = false;
+        for (let i = 0; i < this.windows.length; i ++){
+            let window = this.windows[i].browserWindow;
+            if (window.isVisible()){
+                visible = true;
+            }
+            if (window.isFocused()){
+                focus = true;
+            }
+        }
+        return visible && focus;
+    }
+}
+
+
+/**
+ * Basic keyboard commands
+ */
+class KeyboardCommands{
+
+    static copy = function() {
+        webContents.getFocusedWebContents().copy();
+    };
+
+    static paste = function() {
+        webContents.getFocusedWebContents().paste();
+    };
+
+    static cut = function() {
+        webContents.getFocusedWebContents().cut()
+    };
+
+    static zoomIn = function() {
+        let contents = webContents.getFocusedWebContents();
+        contents.getZoomLevel( (zoom) => {
+            contents.setZoomLevel(zoom + 1);
+        });
+    };
+
+    static zoomOut = function() {
+        let contents = webContents.getFocusedWebContents();
+        contents.getZoomLevel( (zoom) => {
+            contents.setZoomLevel(zoom - 1);
+        });
+    };
+}


### PR DESCRIPTION
This removes the need for an "Edit" menu by implementing keyboard shortcuts without putting them in the menu. Electron requires local shortcuts to be in the menubar, so instead the keyboard shortcuts are implemented as global shortcuts that are registered on application focus and unregistered when the application loses focus. Right now, it registers copy, cut, paste, zoom-in, and zoom-out, and others can added if needed. 