### PR TITLE
Fix start new server when no windows exist

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -299,7 +299,7 @@ export class JupyterApplication {
      */
     constructor() {
         this.registerListeners();
-        this.menu = new JupyterMainMenu();
+        this.menu = new JupyterMainMenu(this);
         this.serverFactory = new JupyterServerFactory();
         
         this.appStateDB.fetch(APPLICATION_STATE_NAMESPACE)
@@ -417,5 +417,20 @@ export class JupyterApplication {
         for (let window of state.windows) {
             this.createWindow(window)
         }
+    }
+
+    /**
+    * Create a new window running on a new local server 
+    */
+    public newLocalServer(){
+        this.createWindow({state: 'local'});
+    }
+
+    /**
+    * Create a new window prompting user for server information
+    * Does not start a new local server (unless prompted by user)
+    */
+    public addServer(){
+        this.createWindow({state: 'new'});
     }
 }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -292,7 +292,11 @@ export class JupyterApplication {
     /**
      * The JupyterLab window
      */
-    private windows: JupyterLabWindow[] = [];
+    private _windows: JupyterLabWindow[] = [];
+    
+    get windows(): JupyterLabWindow[] {
+        return this._windows;
+    }
 
     /**
      * Construct the Jupyter application
@@ -329,20 +333,20 @@ export class JupyterApplication {
             }
             
             // If this is the last open window, save the state so we can reopen it
-            if (this.windows.length == 1) {
+            if (this._windows.length == 1) {
                 if (!this.appState) this.appState = {windows: null};
-                this.appState.windows = this.windows.map((w: JupyterLabWindow) => {
+                this.appState.windows = this._windows.map((w: JupyterLabWindow) => {
                     return w.windowState;
                 });
             }
         });
         
         window.browserWindow.on('closed', (event: Event) => {
-            ArrayExt.removeFirstOf(this.windows, window);
+            ArrayExt.removeFirstOf(this._windows, window);
             window = null;
         });
         
-        this.windows.push(window);
+        this._windows.push(window);
     }
 
     /**
@@ -361,11 +365,11 @@ export class JupyterApplication {
         // windows open.
         // Need to double check this code to ensure it has expected behaviour
         app.on('activate', () => {
-            if (this.windows.length === 0) {
+            if (this._windows.length === 0) {
                 this.createWindow({state: 'local'});
             }
             else if (BrowserWindow.getFocusedWindow() === null){
-                this.windows[0].browserWindow.focus();
+                this._windows[0].browserWindow.focus();
             }
         });
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -36,6 +36,8 @@ import {
 } from '@phosphor/algorithm';
 
 
+
+
 export
 class JupyterServer {
     /**
@@ -389,14 +391,14 @@ export class JupyterApplication {
         
         ipcMain.on(AppIPC.REQUEST_ADD_SERVER, (event: any, arg: any) => {
             this.createWindow({state: 'new'});
-        })
+        });
         
         ipcMain.on(AppIPC.REQUEST_OPEN_CONNECTION, (event: any, arg: ServerIPC.ServerDesc) => {
             if (arg.type == 'remote')
                 this.createWindow({state: 'remote', serverId: arg.id});
             else
                 this.createWindow({state: 'local'});
-        })
+        });
     }
 
     /**

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import {
-    Menu, MenuItem, ipcMain
+    Menu, MenuItem, ipcMain, BrowserWindow
 } from 'electron';
 
 import {
@@ -12,7 +12,8 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-    JupyterMenuIPC as MenuIPC
+    JupyterMenuIPC as MenuIPC,
+    JupyterApplicationIPC as AppIPC
 } from 'jupyterlab_app/src/ipc';
 
 type JupyterMenuItemOptions = MenuIPC.JupyterMenuItemOptions;
@@ -109,7 +110,24 @@ class JupyterMainMenu {
      * Click event handler. Passes the event on the render process 
      */
     private handleClick(menu: Electron.MenuItem, window: Electron.BrowserWindow): void {
-        window.webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
+        let windows: Electron.BrowserWindow[] = null;
+        if (window){
+             window.webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
+        }
+        // No focused window
+        else if ((windows = BrowserWindow.getAllWindows()).length > 0){
+            windows[0].webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
+        }
+        // No window
+        else {
+            if (menu.label === 'Add Server'){
+                ipcMain.emit(AppIPC.REQUEST_ADD_SERVER);
+            }
+            else if (menu.label === 'Local'){
+                ipcMain.emit(AppIPC.REQUEST_OPEN_CONNECTION, null, {type: 'local'});
+            }
+
+        }
     }
 
     private addEditMenu(){

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import {
-    Menu, MenuItem, ipcMain, BrowserWindow
+    Menu, MenuItem, ipcMain
 } from 'electron';
 
 import {
@@ -18,6 +18,10 @@ import {
 import {
     JupyterApplication
 } from './app';
+
+import {
+    JupyterLabWindow
+} from './window';
 
 type JupyterMenuItemOptions = MenuIPC.JupyterMenuItemOptions;
 
@@ -117,14 +121,16 @@ class JupyterMainMenu {
      * Click event handler. Passes the event on the render process 
      */
     private handleClick(menu: Electron.MenuItem, window: Electron.BrowserWindow): void {
-        let windows: Electron.BrowserWindow[] = null;
+        let windows: JupyterLabWindow[] = null;
         // Application window is in focus
         if (window){
              window.webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
         }
         // No focused window
-        else if ((windows = BrowserWindow.getAllWindows()).length > 0){
-            windows[0].webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
+        else if ((windows = this.jupyterApp.windows).length > 0){
+            if (menu.label === 'Add Server' || menu.label === 'Local'){
+                windows[0].browserWindow.webContents.send(MenuIPC.POST_CLICK_EVENT, menu as JupyterMenuItemOptions);
+            }
         }
         // No application windows available
         else {


### PR DESCRIPTION
Fixes #79. Handles the cases when the user selects "Server -> Local" or "Server -> Add Server" from the menubar when there are no windows open or if all windows are minimized. 