### PR TITLE
Use electron-builder to publish releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,47 @@
 osx_image: xcode8.3
+
 dist: trusty
+
 sudo: required
+
 services:
 - docker
+
 language: node_js
 node_js: '6'
 os:
 - linux
 - osx
+
 env:
   global:
   - ELECTRON_CACHE=$HOME/.cache/electron
   - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
 cache:
   directories:
   - "$HOME/.yarn-cache"
+
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-key adv --keyserver pgp.mit.edu  --recv D101F7899D41F3C3; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "deb http://dl.yarnpkg.com/debian/  stable main" | sudo tee /etc/apt/sources.list.d/yarn.list; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq yarn; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull electronuserland/electron-builder:wine; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew install --ignore-dependencies yarn  ; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew install rpm  ; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then brew install --ignore-dependencies yarn; fi
 
 install:
-- yarn install
+- if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then yarn install; fi
+
 script:
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn dockerdist:linux; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn dockerdist:win; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then docker run --rm -ti -e GH_TOKEN=$GH_TOKEN --env-file <(env | grep TRAVIS) -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c "yarn && yarn dist:linux"; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then docker run --rm -ti -e GH_TOKEN=$GH_TOKEN --env-file <(env | grep TRAVIS) -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c "yarn && yarn dist:win"; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then yarn dist:mac; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then yarn dist:linux; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then yarn dist:win; fi
 
 
 before_cache:
 - rm -rf $HOME/.cache/electron-builder/wine
+
+
 notifications:
   email: false
-  
-  
-deploy:
-  provider: releases
-  api_key:
-    secure: JyiiIlzx5Z4IZY/otId/fatDdXOQLXx7eW0DR+4frnfebMN9Keaj0O/e24Gk4qGamcdBUcwaYr1f6WFm4zM2VprDuekMRZbP3vbYa4YfK10k5PG1OMB2eMnuKrjyCCgwDKKYkqwJ4XrzoVofRcOPSDYniKSmroXoqGcJsJWbj2DWgWlSD3hRQVRFG3oG+JxH3pknMP4+e6WImumHWLrCcJgov1fQHqIdInVZ8k99oYKGeIaiASQ7y1VJgB+wxbo1IQXSAgkD1R3EOE/yMY/woyxstwjpNTlWR4T6XpUlCxia9yDfQokDUAU7sULY7kg4CMCQx8qQwsGa8BTmsPhgDPHrOeysHRW3F0wP55JfsJv6d58ImBbKTjOOqt7/m7eBuIV58I6dSc7zXak+HfyO2Z2kQsxKpVgBFEQ8Eloexx1IjFGWPaDjPqia8vOFb7F+i2I8nZMW2a1PQerywy5WRX9GRqJEAHEcDREmlrD5t6Uxge3tpFMm7MgdLND4Bh13yJB8uihsby/ViW6y4nVbBPj2w8jeEvnx426APUxkJKQYy8k3mZWnSnzNtaDvcR1F0YSQSCEFv3kXNtaCWjpJ6A9gHTlCjYwKMvZ32H8SNlYRrP90y0EUGFui4bmw5DJl+4HOKy/EHJVm6LDzhWgGmuoT46ZxexE+s7Dy3+aq13M=
-  draft: true
-  file_glob: true
-  file: 
-    - dist/*.exe
-    - dist/*.AppImage
-    - dist/*.tar.gz
-    - dist/*.zip
-    - dist/*.dmg
-    - dist/*.deb
-    - dist/*.rpm
-  skip_cleanup: true
-  on:
-    tags: true
-    all_branches: true
-    condition: "$TRAVIS_OS_NAME = osx"

--- a/Release.md
+++ b/Release.md
@@ -1,11 +1,19 @@
 # Releasing through Travis-CI
 
-1. Commit and push all your changes, you need to have a clean git repo locally
-2. Run `npm version minor/major/patch` to update the version in package.json and create a tag and an individual commit
-3. Push the newly created commit and tag 
-4. Travis-CI will build for macOS, Linux, and Windows and release them in a Github release Draft, that will need to be hand-polished and published.
+### Workflow 1
 
-At the present time in Travis-CI due to a [bug](https://github.com/electron-userland/electron-builder/issues/1871) in electron-builder all artifacts are built on macOS and deployed by travis as a Github release draft.
+1. Draft a new release on Github. Set the "Tag version" to the value of version in your application package.json, and prefix it with v. "Release title" can be anything you want.
+For example, if your application package.json version is 1.0, your draft's "Tag version" would be v1.0.
+2. Push some commits. Every CI build will update the artifacts attached to this draft.
+3. Once you are done, publish the release. GitHub will tag the latest commit for you.
+
+The benefit of this workflow is that it allows you to always have the latest artifacts, and the release can be published once it is ready.
+
+### Workflow 2
+
+1. run `npm version major/minor/patch` to tag and generate a commit
+2. push the commit and the tag
+3. The CI will draft a release with the correct "Tag version" from your package.json file
 
 
 # Dependencies

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "build": "npm run build:main && npm run build:browser",
     "build:all": "npm run build && npm start",
     "pack": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder --publish never",
-    "dist:linux": "npm run build && electron-builder --linux --publish never",
+    "dist": "npm run build && electron-builder",
+    "dist:linux": "npm run build && electron-builder --linux",
     "dockerdist:linux": "docker run --rm -ti -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c \"yarn && yarn dist:linux\"",
-    "dist:mac": "npm run build && electron-builder --macos --publish never",
-    "dist:win": "npm run build && electron-builder --win --publish never",
+    "dist:mac": "npm run build && electron-builder --macos",
+    "dist:win": "npm run build && electron-builder --win",
     "dockerdist:win": "docker run --rm -ti -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c \"yarn && yarn dist:win\"",
     "release": "electron-builder --publish onTagOrDraft"
   },
@@ -57,10 +57,6 @@
       "deleteAppDataOnUninstall": true,
       "license": "LICENSE"
     }
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jupyterlab/jupyterlab_app.git"
   },
   "author": {
     "name": "Project Jupyter",


### PR DESCRIPTION
WIth this PR electron-builder is usued to release on github, with the advantaged of improved workflow and build time.

A Protected environmental variable called GH_TOKEN needs to be set in travis for this PR to work https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts