### PR TITLE
Styled and added in the title bar controls for windows

### DIFF
--- a/src/browser/components/titlebar/img/close-hover.svg
+++ b/src/browser/components/titlebar/img/close-hover.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <g id="Group" stroke="#FFFFFF">
+            <path d="M0.908003116,0.908003116 L13.0919969,13.0919969" id="Line"></path>
+            <path d="M13.0919969,0.908003116 L0.908003116,13.0919969" id="Line"></path>
+        </g>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/close-icon.svg
+++ b/src/browser/components/titlebar/img/close-icon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="6px" height="6px" viewBox="0 0 6 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 45.2 (43514) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" transform="translate(-3.000000, -3.000000)" fill="#7E0508">
+            <path d="M6.56081283,5.92741911 L8.31670294,4.14061236 L7.74610257,3.57988494 L6,5.35673183 L4.25389743,3.57988494 L3.68329706,4.14061236 L5.43918717,5.92741911 L3.54064698,7.85938764 L4.11124735,8.42011506 L6,6.4981064 L7.88875265,8.42011506 L8.45935302,7.85938764 L6.56081283,5.92741911 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/close.svg
+++ b/src/browser/components/titlebar/img/close.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <g id="Group" stroke="#BDBDBD">
+            <path d="M0.908003116,0.908003116 L13.0919969,13.0919969" id="Line"></path>
+            <path d="M13.0919969,0.908003116 L0.908003116,13.0919969" id="Line"></path>
+        </g>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/expand-hover.svg
+++ b/src/browser/components/titlebar/img/expand-hover.svg
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
-    <title>Rectangle 2</title>
+    <title>expand-hover</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect id="Rectangle-2" stroke="#757575" x="0.5" y="0.5" width="13" height="13"></rect>
+        <g id="expand-hover" stroke="#424242">
+            <rect id="Rectangle-2" x="0.5" y="0.5" width="13" height="13"></rect>
+        </g>
     </g>
 </svg>

--- a/src/browser/components/titlebar/img/expand-hover.svg
+++ b/src/browser/components/titlebar/img/expand-hover.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle 2</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle-2" stroke="#757575" x="0.5" y="0.5" width="13" height="13"></rect>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/expand.svg
+++ b/src/browser/components/titlebar/img/expand.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle 2</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle-2" stroke="#BDBDBD" x="0.5" y="0.5" width="13" height="13"></rect>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/minimize-hover.svg
+++ b/src/browser/components/titlebar/img/minimize-hover.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="14px" height="2px" viewBox="0 0 14 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="30px" height="2px" viewBox="0 0 30 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
     <title>minimize-hover</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="minimize-hover" transform="translate(0.000000, -6.000000)">
-            <rect id="Rectangle-2" x="0" y="0" width="14" height="14"></rect>
-            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#424242" stroke-linecap="square"></path>
+        <g id="minimize-hover" transform="translate(0.000000, -13.000000)">
+            <rect id="Rectangle-2" x="0.5" y="0" width="28" height="28"></rect>
+            <path d="M1,14 L29,14" id="Line-2" stroke="#424242" stroke-width="2" stroke-linecap="square"></path>
         </g>
     </g>
 </svg>

--- a/src/browser/components/titlebar/img/minimize-hover.svg
+++ b/src/browser/components/titlebar/img/minimize-hover.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="14px" height="2px" viewBox="0 0 14 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 2</title>
+    <title>minimize-hover</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-2" transform="translate(0.000000, -6.000000)">
+        <g id="minimize-hover" transform="translate(0.000000, -6.000000)">
             <rect id="Rectangle-2" x="0" y="0" width="14" height="14"></rect>
-            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#757575" stroke-linecap="square"></path>
+            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#424242" stroke-linecap="square"></path>
         </g>
     </g>
 </svg>

--- a/src/browser/components/titlebar/img/minimize-hover.svg
+++ b/src/browser/components/titlebar/img/minimize-hover.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="2px" viewBox="0 0 14 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 2</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-2" transform="translate(0.000000, -6.000000)">
+            <rect id="Rectangle-2" x="0" y="0" width="14" height="14"></rect>
+            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#757575" stroke-linecap="square"></path>
+        </g>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/img/minimize.svg
+++ b/src/browser/components/titlebar/img/minimize.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="14px" height="2px" viewBox="0 0 14 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="30px" height="2px" viewBox="0 0 30 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 2</title>
+    <title>minimize</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-2" transform="translate(0.000000, -6.000000)">
-            <rect id="Rectangle-2" x="0" y="0" width="14" height="14"></rect>
-            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#BDBDBD" stroke-linecap="square"></path>
+        <g id="minimize" transform="translate(0.000000, -13.000000)">
+            <rect id="Rectangle-2" x="0.5" y="0" width="28" height="28"></rect>
+            <path d="M1,14 L29,14" id="Line-2" stroke="#BDBDBD" stroke-width="2" stroke-linecap="square"></path>
         </g>
     </g>
 </svg>

--- a/src/browser/components/titlebar/img/minimize.svg
+++ b/src/browser/components/titlebar/img/minimize.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="2px" viewBox="0 0 14 2" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 2</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-2" transform="translate(0.000000, -6.000000)">
+            <rect id="Rectangle-2" x="0" y="0" width="14" height="14"></rect>
+            <path d="M0.5,7 L13.5,7" id="Line-2" stroke="#BDBDBD" stroke-linecap="square"></path>
+        </g>
+    </g>
+</svg>

--- a/src/browser/components/titlebar/style/index.css
+++ b/src/browser/components/titlebar/style/index.css
@@ -40,8 +40,7 @@
     height: 100%;
     display: flex;
     align-items: center;
-    float: left;
-    padding: 0 3px 0 3px;
+    flex-direction: row-reverse;
 }
 
 .jpe-TitleBar-button-container.jpe-mod-linux {
@@ -52,29 +51,43 @@
     float: right;
 }
 
-.jpe-TitleBar-button {
-    border-radius: 50%;
-    height: 7px;
-    width: 7px;
-    margin: 0 3px 0 3px;
+.jpe-TitleBar-button.jpe-mod-windows {
+    height: 100%;
+    width: 44px;
     -webkit-app-region: no-drag;
+    background-size: 14px;
+    background-position: center;
+    background-repeat: no-repeat;
 }
 
-.jpe-TitleBar-button:hover {
-    box-shadow: 1px 1px 1px #555555;
+.jpe-TitleBar-button.jpe-mod-windows:hover {
+    background-color: #E0E0E0;
 }
 
-.jpe-TitleBar-close {
-    background-color: red;
-    border: 1px solid #882222
+.jpe-TitleBar-close.jpe-mod-windows {
+    background-color: var(--jp-layout-color0);
+    background-image: url('../img/close.svg');
 }
 
-.jpe-TitleBar-min {
-    background-color: yellow;
-    border: 1px solid #c49412;
+.jpe-TitleBar-close.jpe-mod-windows:hover {
+    background-color: #EF5350;
+    background-image: url('../img/close-hover.svg');
 }
 
-.jpe-TitleBar-max {
-    background-color: green;
-    border: 1px solid #115511;
+.jpe-TitleBar-min.jpe-mod-windows {
+    background-color: var(--jp-layout-color0);
+    background-image: url('../img/minimize.svg');
+}
+
+.jpe-TitleBar-min.jpe-mod-windows:hover {
+    background-image: url('../img/minimize-hover.svg');
+}
+
+.jpe-TitleBar-max.jpe-mod-windows {
+    background-color: var(--jp-layout-color0);
+    background-image: url('../img/expand.svg');
+}
+
+.jpe-TitleBar-max.jpe-mod-windows:hover {
+    background-image: url('../img/expand-hover.svg');
 }

--- a/src/browser/components/titlebar/titlebar.tsx
+++ b/src/browser/components/titlebar/titlebar.tsx
@@ -64,8 +64,8 @@ class TitleBar extends React.Component<TitleBar.Props, TitleBar.State> {
             content = (
                 <div className={'jpe-TitleBar-button-container ' + modClass}>
                     <div className={'jpe-TitleBar-button jpe-TitleBar-close ' + modClass} onClick={() => {clicked('close')}} />
-                    <div className={'jpe-TitleBar-button jpe-TitleBar-max ' + modClass} onClick={() => {clicked('minimize')}} />
-                    <div className={'jpe-TitleBar-button jpe-TitleBar-min ' + modClass} onClick={() => {clicked('maximize')}} />
+                    <div className={'jpe-TitleBar-button jpe-TitleBar-max ' + modClass} onClick={() => {clicked('maximize')}} />
+                    <div className={'jpe-TitleBar-button jpe-TitleBar-min ' + modClass} onClick={() => {clicked('minimize')}} />
                 </div>
             );
         }

--- a/src/browser/components/titlebar/titlebar.tsx
+++ b/src/browser/components/titlebar/titlebar.tsx
@@ -64,8 +64,8 @@ class TitleBar extends React.Component<TitleBar.Props, TitleBar.State> {
             content = (
                 <div className={'jpe-TitleBar-button-container ' + modClass}>
                     <div className={'jpe-TitleBar-button jpe-TitleBar-close ' + modClass} onClick={() => {clicked('close')}} />
-                    <div className={'jpe-TitleBar-button jpe-TitleBar-min ' + modClass} onClick={() => {clicked('minimize')}} />
-                    <div className={'jpe-TitleBar-button jpe-TitleBar-max ' + modClass} onClick={() => {clicked('maximize')}} />
+                    <div className={'jpe-TitleBar-button jpe-TitleBar-max ' + modClass} onClick={() => {clicked('minimize')}} />
+                    <div className={'jpe-TitleBar-button jpe-TitleBar-min ' + modClass} onClick={() => {clicked('maximize')}} />
                 </div>
             );
         }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -43,6 +43,10 @@ class JupyterLabWindow {
             }
         }
         
+        let titleBarStyle: 'default' | 'hidden' = 'default';
+        if (this._info.uiState == 'mac') {
+            titleBarStyle = 'hidden';
+        }
         let showFrame = false;
         if (this._info.uiState == 'linux') {
             showFrame = true;
@@ -59,7 +63,7 @@ class JupyterLabWindow {
             frame: showFrame,
             show: false,
             title: 'JupyterLab',
-            titleBarStyle: 'hidden'
+            titleBarStyle: titleBarStyle
         });
 
         ipcMain.on(WindowIPC.REQUEST_STATE_UPDATE, (evt: any, arg: any) => {


### PR DESCRIPTION
Styled the title bar controls per request of the team! Since we are only going to be using these icons for windows, I just added the `jpe-mod-windows` class to all of the icons in the CSS.

## Before
![screen shot 2017-08-02 at 5 17 01 pm](https://user-images.githubusercontent.com/6437976/28900484-6d680d02-77a6-11e7-8cfd-5bcc4a07d5dd.png)

## After
![screen shot 2017-08-02 at 5 15 39 pm](https://user-images.githubusercontent.com/6437976/28900493-73b86864-77a6-11e7-9dbb-2fb76ba124f1.png)

![screen shot 2017-08-02 at 5 15 43 pm](https://user-images.githubusercontent.com/6437976/28900495-76c6963e-77a6-11e7-8e76-f76b93f77da9.png)

![screen shot 2017-08-02 at 5 15 46 pm](https://user-images.githubusercontent.com/6437976/28900498-7a0d6714-77a6-11e7-8a6d-62f2f054c7e2.png)

