### PR TITLE
Fix maximize button on Windows

### DIFF
--- a/src/browser/components/titlebar/titlebar.tsx
+++ b/src/browser/components/titlebar/titlebar.tsx
@@ -52,7 +52,11 @@ class TitleBar extends React.Component<TitleBar.Props, TitleBar.State> {
             } else if (type == 'minimize') {
                 remote.getCurrentWindow().minimize();
             } else {
-                remote.getCurrentWindow().maximize();
+                let window = remote.getCurrentWindow();
+                if (window.isMaximized())
+                    window.restore();
+                else
+                    window.maximize();
             }
         }
         


### PR DESCRIPTION
The maximize button on Windows restores it to the original window size when clicked in the maximized state. The icon still needs to be changed, but this fixes the functionality. 