### PR TITLE
Show error screen when Jupyter server is not installed

### DIFF
--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -18,7 +18,7 @@ import {
 } from 'jupyterlab_app/src/ipc';
 
 import {
-    SplashScreen, ServerManager, TitleBar
+    SplashScreen, ServerManager, TitleBar, ServerError
 } from 'jupyterlab_app/src/browser/components';
 
 import {
@@ -45,13 +45,15 @@ class Application extends React.Component<Application.Props, Application.State> 
         this._renderServerManager = this._renderServerManager.bind(this);
         this._renderSplash = this._renderSplash.bind(this);
         this._renderLab = this._renderLab.bind(this);
+        this._renderErrorScreen = this._renderErrorScreen.bind(this);
         this._connectionAdded = this._connectionAdded.bind(this);
 
         this._labReady = this._setupLab();
         
         ipcRenderer.on(ServerIPC.RESPOND_SERVER_STARTED, (event: any, data: ServerIPC.IServerStarted) => {
             if (data.err) {
-                console.log('Error starting local server, show error screen');
+                console.error(data.err);
+                this.setState({renderState: this._renderErrorScreen});
                 return;
             }
             
@@ -186,7 +188,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         });
     }
 
-    private _renderServerManager(): any {
+    private _renderServerManager(): JSX.Element {
         return (
             <div className='jpe-content'>
                 <TitleBar uiState={this.props.options.uiState} />
@@ -195,7 +197,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         );
     }
 
-    private _renderSplash() {
+    private _renderSplash(): JSX.Element {
         return (
             <div className='jpe-content'>
                 <SplashScreen  ref='splash' uiState={this.props.options.uiState} finished={() => {
@@ -205,10 +207,19 @@ class Application extends React.Component<Application.Props, Application.State> 
         );
     }
 
-    private _renderLab(): any {
+    private _renderLab(): JSX.Element {
         this._saveState();
 
         return null;
+    }
+
+    private _renderErrorScreen(): JSX.Element {
+        return (
+            <div className='jpe-content'>
+                <TitleBar uiState={this.props.options.uiState} />
+                <ServerError />
+            </div>
+        )
     }
 
     private _lab: ElectronJupyterLab;

--- a/src/browser/components/error/index.ts
+++ b/src/browser/components/error/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import './style/index.css';
+
+export * from './servererror';

--- a/src/browser/components/error/servererror.tsx
+++ b/src/browser/components/error/servererror.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import * as React from 'react';
+
+export
+function ServerError() {
+    return (
+        <div className='jpe-ServerError-body'>
+            <div className='jpe-ServerError-content' >
+                <h1>Something Went Wrong!</h1>
+                <p>Looks like the Jupyter Server isn't installed. Take a look at jupyter.org for help with installation.</p>
+            </div>
+        </div>
+    );
+}

--- a/src/browser/components/error/style/index.css
+++ b/src/browser/components/error/style/index.css
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jpe-ServerError-body {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    background-color: #ffffff;
+    display: flex;
+    align-items: center;
+}
+
+.jpe-ServerError-content {
+    margin: auto;
+    width: 400px;
+    height: 300px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}

--- a/src/browser/components/index.ts
+++ b/src/browser/components/index.ts
@@ -5,3 +5,4 @@
 export * from './servermanager';
 export * from './splashscreen';
 export * from './titlebar';
+export * from './error';

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -51,14 +51,14 @@ class JupyterServer {
             }
 
             this._nbServer.on('error', (err: Error) => {
-                this._nbServer.stderr.removeAllListeners();
+                this._cleanupListeners();
                 reject(err);
             });
 
             this._nbServer.stderr.on('data', (serverBuff: string) => {
                 let errorMatch = serverBuff.toString().match(errorRegExp);
                 if (errorMatch) {
-                    this._nbServer.stderr.removeAllListeners();
+                    this._cleanupListeners();
                     reject(new Error('Jupyter not insatlled'));
                     return;
                 }
@@ -72,9 +72,8 @@ class JupyterServer {
                     token: (url.match(tokenRegExp))[0].replace("token=", ""),
                     url: (url.match(baseRegExp))[0]
                 }
-                this._nbServer.removeAllListeners();
-                this._nbServer.stderr.removeAllListeners();
 
+                this._cleanupListeners();
                 resolve(this._info);
             });
 
@@ -114,6 +113,11 @@ class JupyterServer {
             }
         });
         return this._stopServer;
+    }
+
+    private _cleanupListeners() {
+        this._nbServer.removeAllListeners();
+        this._nbServer.stderr.removeAllListeners();
     }
     
     /**

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -38,6 +38,7 @@ class JupyterServer {
             let urlRegExp = /http:\/\/localhost:\d+\/\?token=\w+/g;
             let tokenRegExp = /token=\w+/g;
             let baseRegExp = /http:\/\/localhost:\d+\//g;
+            let errorRegExp = /not found/g;
             let home = app.getPath("home");
 
             // Windows will return win32 (even for 64-bit)
@@ -55,6 +56,13 @@ class JupyterServer {
             });
 
             this._nbServer.stderr.on('data', (serverBuff: string) => {
+                let errorMatch = serverBuff.toString().match(errorRegExp);
+                if (errorMatch) {
+                    this._nbServer.stderr.removeAllListeners();
+                    reject(new Error('Jupyter not insatlled'));
+                    return;
+                }
+
                 let urlMatch = serverBuff.toString().match(urlRegExp);
                 if (!urlMatch)
                     return; 


### PR DESCRIPTION
This PR adds a very simple error screen that appears when Jupyter is not installed. This is a very basic implementation that will eventually be made more robust.