### PR TITLE
Add some Linux build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 A native app for [JupyterLab](https://github.com/jupyterlab/jupyterlab), based on [Electron](https://electron.atom.io/).
 
+### Build dependencies
+
+#### Linux
+
+You will need the development packages of libcairo, libjpeg, and libgif.  In Debian-based distributions, these are provided by the `libcairo2-dev`, `libjpeg8-dev`, and `libgif-dev` packages.
+
 ### Getting started
 
 1. run `git clone git@github.com:jupyterlab/jupyterlab_app.git`
@@ -14,7 +20,7 @@ A native app for [JupyterLab](https://github.com/jupyterlab/jupyterlab), based o
 ### Building for distribution
 
 To test building for distribution you can install [Docker](https://docs.docker.com/engine/installation/) and run `yarn dockerdist:platform` where "platform" is either "linux", "win" or "mac".
- 
-If you don't want to user Docker but instead want to build locally, there are a few [dependencies](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build) you're required to install. 
+
+If you don't want to user Docker but instead want to build locally, there are a few [dependencies](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build) you're required to install.
 
 Regarding releasing please check out [release](release.md)


### PR DESCRIPTION
I was unable to complete the `npm install` step until I installed some dev packages on my Ubuntu Linux 14.04 machine.  I thought I would document them here for the next person.