### PR TITLE
Trigger error screen if Jupyter server is outdated

### DIFF
--- a/src/browser/components/error/servererror.tsx
+++ b/src/browser/components/error/servererror.tsx
@@ -9,7 +9,7 @@ function ServerError() {
         <div className='jpe-ServerError-body'>
             <div className='jpe-ServerError-content' >
                 <h1>Something Went Wrong!</h1>
-                <p>Looks like the Jupyter Server isn't installed. Take a look at jupyter.org for help with installation.</p>
+                <p>Looks like the Jupyter Server isn't installed, isn't in your path, or is outdated. Take a look at jupyter.org for help with installation.</p>
             </div>
         </div>
     );

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -35,7 +35,7 @@ class JupyterServer {
         }
 
         this._startServer = new Promise<JupyterServer.IInfo>((resolve, reject) => {
-            let urlRegExp = /http:\/\/localhost:\d+\/\?token=\w+/g;
+            let urlRegExp = /http:\/\/localhost:\d+\/\S*/g;
             let tokenRegExp = /token=\w+/g;
             let baseRegExp = /http:\/\/localhost:\d+\//g;
             let home = app.getPath("home");
@@ -62,11 +62,25 @@ class JupyterServer {
             this._nbServer.stderr.on('data', (serverBuff: string) => {
                 let urlMatch = serverBuff.toString().match(urlRegExp);
                 if (!urlMatch)
-                    return; 
+                    return;
 
-                let url = urlMatch[0].toString();
+                let url = null;
+                if (urlMatch.length > 1){
+                    url = urlMatch[0].toString();
+                }
+                else {
+                    url = urlMatch.toString();
+                }
+
+                let token = (url.match(tokenRegExp))
+                if (token === null) {
+                    this._cleanupListeners();
+                    reject(new Error("Update Jupyter version"));
+                    return;
+                }
+                
                 this._info = {
-                    token: (url.match(tokenRegExp))[0].replace("token=", ""),
+                    token: token[0].replace("token=", ""),
                     url: (url.match(baseRegExp))[0]
                 }
 

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -65,7 +65,7 @@ class JupyterServer {
                     return;
 
                 let url = null;
-                if (urlMatch.length > 1){
+                if (urlMatch.length > 0){
                     url = urlMatch[0].toString();
                 }
                 else {

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -64,16 +64,10 @@ class JupyterServer {
                 if (!urlMatch)
                     return;
 
-                let url = null;
-                if (urlMatch.length > 0){
-                    url = urlMatch[0].toString();
-                }
-                else {
-                    url = urlMatch.toString();
-                }
-
-                let token = (url.match(tokenRegExp))
-                if (token === null) {
+                let url = urlMatch[0].toString();
+                let token = (url.match(tokenRegExp));
+                
+                if (!token) {
                     this._cleanupListeners();
                     reject(new Error("Update Jupyter version"));
                     return;


### PR DESCRIPTION
This fixes #112. Older versions of the Jupyter server don't include a token, so the application was getting hung up on the splash screen. This now throws them into the "Something Went Wrong" page that tells them Jupyter either isn't installed, isn't in their path, or needs to be updated.

@lucbouchard1 is improving the Jupyter detection/environment selection process. This is just so users don't get stuck on the splash screen without any feedback. 