### PR TITLE
Add error page transition and logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A native app for JupyterLab, based on electron.",
   "main": "build/main.bundle.js",
   "scripts": {

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -54,7 +54,8 @@ class Application extends React.Component<Application.Props, Application.State> 
         ipcRenderer.on(ServerIPC.RESPOND_SERVER_STARTED, (event: any, data: ServerIPC.IServerStarted) => {
             if (data.err) {
                 console.error(data.err);
-                this.setState({renderState: this._renderErrorScreen});
+                this.setState({renderSplash: this._renderSplash, renderState: this._renderErrorScreen});
+                (this.refs.splash as SplashScreen).fadeSplashScreen();
                 return;
             }
             
@@ -86,10 +87,11 @@ class Application extends React.Component<Application.Props, Application.State> 
         });
 
         if (this.props.options.serverState == 'local') {
-            this.state = {renderState: this._renderSplash, remotes: []};
+            this.state = {renderSplash: this._renderSplash, renderState: this._renderEmpty, remotes: []};
             ipcRenderer.send(ServerIPC.REQUEST_SERVER_START);
         } else {
-            this.state = {renderState: this._renderServerManager, remotes: []};
+            this.state = {renderSplash: this._renderSplash, renderState: this._renderServerManager, remotes: []};
+            (this.refs.splash as SplashScreen).fadeSplashScreen();
         }
         
         this._serverState = new StateDB({namespace: Application.STATE_NAMESPACE});
@@ -115,10 +117,12 @@ class Application extends React.Component<Application.Props, Application.State> 
     }
     
     render() {
+        let splash = this.state.renderSplash();
         let content = this.state.renderState();
 
         return (
             <div className='jpe-body'>
+                {splash}
                 {content}
             </div>
         );
@@ -213,7 +217,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         return (
             <div className='jpe-content'>
                 <SplashScreen  ref='splash' uiState={this.props.options.uiState} finished={() => {
-                    this.setState({renderState: this._renderLab});}
+                    this.setState({renderSplash: this._renderEmpty});}
                 } />
             </div>
         );
@@ -221,7 +225,6 @@ class Application extends React.Component<Application.Props, Application.State> 
 
     private _renderLab(): JSX.Element {
         this._saveState();
-
         return null;
     }
 
@@ -232,6 +235,10 @@ class Application extends React.Component<Application.Props, Application.State> 
                 <ServerError launchFromPath={this._launchFromPath}/>
             </div>
         )
+    }
+
+    private _renderEmpty(): JSX.Element {
+        return null;
     }
 
     private _lab: ElectronJupyterLab;
@@ -270,6 +277,7 @@ namespace Application {
     export
     interface State {
         renderState: () => any;
+        renderSplash: () => any;
         remotes: IRemoteServer[];
     }
 

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -44,7 +44,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         super(props);
         this._renderServerManager = this._renderServerManager.bind(this);
         this._renderSplash = this._renderSplash.bind(this);
-        this._renderLab = this._renderLab.bind(this);
+        this._renderEmpty = this._renderEmpty.bind(this);
         this._renderErrorScreen = this._renderErrorScreen.bind(this);
         this._connectionAdded = this._connectionAdded.bind(this);
         this._launchFromPath = this._launchFromPath.bind(this);
@@ -90,8 +90,7 @@ class Application extends React.Component<Application.Props, Application.State> 
             this.state = {renderSplash: this._renderSplash, renderState: this._renderEmpty, remotes: []};
             ipcRenderer.send(ServerIPC.REQUEST_SERVER_START);
         } else {
-            this.state = {renderSplash: this._renderSplash, renderState: this._renderServerManager, remotes: []};
-            (this.refs.splash as SplashScreen).fadeSplashScreen();
+            this.state = {renderSplash: this._renderEmpty, renderState: this._renderServerManager, remotes: []};
         }
         
         this._serverState = new StateDB({namespace: Application.STATE_NAMESPACE});
@@ -197,8 +196,9 @@ class Application extends React.Component<Application.Props, Application.State> 
         this.setState((prev: ServerManager.State) => {
             server.id = this._nextRemoteId++;
             let conns = this.state.remotes.concat(rServer);
+            this._saveState();
             return({
-                renderState: this._renderLab,
+                renderState: this._renderEmpty,
                 conns: {servers: conns}
             });
         });
@@ -221,11 +221,6 @@ class Application extends React.Component<Application.Props, Application.State> 
                 } />
             </div>
         );
-    }
-
-    private _renderLab(): JSX.Element {
-        this._saveState();
-        return null;
     }
 
     private _renderErrorScreen(): JSX.Element {

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -54,7 +54,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         ipcRenderer.on(ServerIPC.RESPOND_SERVER_STARTED, (event: any, data: ServerIPC.IServerStarted) => {
             if (data.err) {
                 console.error(data.err);
-                this.setState({renderSplash: this._renderSplash, renderState: this._renderErrorScreen});
+                this.setState({renderState: this._renderErrorScreen});
                 (this.refs.splash as SplashScreen).fadeSplashScreen();
                 return;
             }
@@ -131,8 +131,8 @@ class Application extends React.Component<Application.Props, Application.State> 
         ipcRenderer.send(ServerIPC.REQUEST_SERVER_START_PATH);
 
         let pathSelected = () => {
-            this.setState({renderState: this._renderSplash});
             ipcRenderer.removeListener(ServerIPC.POST_PATH_SELECTED, pathSelected);
+            this.setState({renderSplash: this._renderSplash, renderState: this._renderEmpty});
         }
         ipcRenderer.on(ServerIPC.POST_PATH_SELECTED, pathSelected);
     }
@@ -192,7 +192,6 @@ class Application extends React.Component<Application.Props, Application.State> 
         });
 
         let rServer: Application.IRemoteServer = {...server, id: this._nextRemoteId++};
-
         this.setState((prev: ServerManager.State) => {
             server.id = this._nextRemoteId++;
             let conns = this.state.remotes.concat(rServer);

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -48,7 +48,7 @@ class JupyterServer {
             let home = app.getPath("home");
 
             if (this._info.path) {
-               this._nbServer = execFile(join(this._info.path, 'jupyter'), ['notebook', '--no-browser']);
+               this._nbServer = execFile(join(this._info.path, 'jupyter'), ['notebook', '--no-browser'], {cwd: home});
             } else if (process.platform === "win32") {
                 // Windows will return win32 (even for 64-bit)
                 // Dont spawn shell for Windows

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -169,10 +169,10 @@ class JupyterServerFactory {
         ipcMain.on(ServerIPC.REQUEST_SERVER_START, (event: any) => {
             this.requestServerStart({})
                 .then((data: JupyterServerFactory.IFactoryItem) => {
-                    event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._factoryToIPC(data))
+                    event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._factoryToIPC(data));
                })
                 .catch((e: any) => {
-                    event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e))
+                    event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
                 });
         });
         
@@ -182,14 +182,16 @@ class JupyterServerFactory {
                     event.sender.send(ServerIPC.POST_PATH_SELECTED);
                     this.requestServerStart({path})
                         .then((data: JupyterServerFactory.IFactoryItem) => {
-                            event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._factoryToIPC(data))
+                            event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._factoryToIPC(data));
                         })
                         .catch((e) => {
-                            event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e))
+                            event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
                         });
                })
                 .catch((e: any) => {
-                    event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e))
+                    if (e.message !== 'cancel'){
+                        event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
+                    }
                 });
         });
         
@@ -289,7 +291,7 @@ class JupyterServerFactory {
                 buttonLabel: 'Use Path'
             }, (filePaths: string[]) => {
                 if (!filePaths) {
-                    rej(new Error('No path selected'));
+                    rej(new Error('cancel'));
                     return;
                 } else {
                     res(filePaths[0]);

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -60,7 +60,7 @@ class JupyterServer {
             
             this._nbServer.on('exit', () => {
                 this._serverStartFailed();
-                reject(new Error('Jupyter not installed'));
+                reject(new Error('Could not find Jupyter in PATH'));
             });
 
             this._nbServer.on('error', (err: Error) => {
@@ -78,7 +78,7 @@ class JupyterServer {
                 
                 if (!token) {
                     this._cleanupListeners();
-                    reject(new Error("Update Jupyter version"));
+                    reject(new Error("Update Jupyter notebook to version 4.3.0 or greater"));
                     return;
                 }
                 
@@ -171,7 +171,7 @@ class JupyterServerFactory {
                 .then((data: JupyterServerFactory.IFactoryItem) => {
                     event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._factoryToIPC(data));
                })
-                .catch((e: any) => {
+                .catch((e: Error) => {
                     event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
                 });
         });
@@ -188,9 +188,10 @@ class JupyterServerFactory {
                             event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
                         });
                })
-                .catch((e: any) => {
+                .catch((e: Error) => {
                     if (e.message !== 'cancel'){
                         event.sender.send(ServerIPC.RESPOND_SERVER_STARTED, this._errorToIPC(e));
+
                     }
                 });
         });
@@ -315,7 +316,7 @@ class JupyterServerFactory {
             factoryId: -1,
             url: null,
             token: null,
-            err: e || new Error('Server creation error')
+            err: e.message || 'Server creation error'
         };
     }
     

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -65,7 +65,7 @@ class JupyterServer {
 
             this._nbServer.on('error', (err: Error) => {
                 this._serverStartFailed();
-                reject(err);
+                reject(new Error('Could not find Jupyter in PATH'));
             });
 
             this._nbServer.stderr.on('data', (serverBuff: string) => {


### PR DESCRIPTION
Improves the transition to the error page. The splash screen now fades into the error page. If the user selects a bad path, the splash screen appears and fades back into the error page. 

On the error page, more information about the problem (can't find Jupyter in path, or Jupyter notebook not up to date) is logged in the dev tools console.