### PR TITLE
Fix bug preventing user from navigating directories

### DIFF
--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -21,13 +21,13 @@ import {
 /**
  * HACK
  * 
- * A JupyterLab package uses process.cwd
- * with the expectation that it returns '/', which
- * it does in the browser. However, in the
- * electron environment, prcess.cwd evaluates
- * to the current working directory of the node
- * application. Here we are overrding it to maintain
- * the bahavior of JupyterLab
+ * The JupyterLab coreutils package uses the process.cwd
+ * function with the expectation that it returns a '/', which
+ * is the case when the code is bundled by webpack. Since this code
+ * is not bundled, and electron gives the render process access node's
+ * `process` variable, prcess.cwd actually evaluates to the current
+ * working directory of the nodeapplication. Here we are overrding it
+ * to maintain the bahavior JupyterLab expects.
  */
 process.cwd = () => {return '/'}
 

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -17,6 +17,21 @@ import {
     JupyterWindowIPC as WindowIPC
 } from '../ipc';
 
+
+/**
+ * HACK
+ * 
+ * A JupyterLab package uses process.cwd
+ * with the expectation that it returns '/', which
+ * it does in the browser. However, in the
+ * electron environment, prcess.cwd evaluates
+ * to the current working directory of the node
+ * application. Here we are overrding it to maintain
+ * the bahavior of JupyterLab
+ */
+process.cwd = () => {return '/'}
+
+
 function main() : void {
     let optionsStr = decodeURIComponent((global as any).location.search);
     let options: WindowIPC.IWindowState = JSON.parse(optionsStr.slice(1));


### PR DESCRIPTION
Patches a bug introduced in PR #123  that made the file browser inoperable.

The JupyterLab 'coreutils' package uses the process.cwd function with the expectation that it returns a '/', which is the case when the code is bundled by webpack. Since this code is not bundled, and electron gives the render process access node's `process` variable, prcess.cwd actually evaluates to the current working directory of the node application. This PR overrides process.cwd to maintain the behavior JupyterLab expects.