### PR TITLE
Implement disabled/deferred/ignored extensions and fix linter problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,5 +188,44 @@
     "which": "^1.3.0",
     "winreg": "^1.2.4",
     "xterm": "^3.0.2"
+  },
+  "jupyterlab": {
+    "name": "JupyterLab",
+    "version": "0.31.5",
+    "extensions": [
+      "./electron-extension",
+      "./utils-extension",
+      "@jupyterlab/codemirror-extension",
+      "@jupyterlab/completer-extension",
+      "@jupyterlab/console-extension",
+      "@jupyterlab/csvviewer-extension",
+      "@jupyterlab/docmanager-extension",
+      "@jupyterlab/faq-extension",
+      "@jupyterlab/filebrowser-extension",
+      "@jupyterlab/fileeditor-extension",
+      "@jupyterlab/help-extension",
+      "@jupyterlab/imageviewer-extension",
+      "@jupyterlab/inspector-extension",
+      "@jupyterlab/launcher-extension",
+      "@jupyterlab/mainmenu-extension",
+      "@jupyterlab/markdownviewer-extension",
+      "@jupyterlab/mathjax2-extension",
+      "@jupyterlab/notebook-extension",
+      "@jupyterlab/rendermime-extension",
+      "@jupyterlab/running-extension",
+      "@jupyterlab/settingeditor-extension",
+      "@jupyterlab/shortcuts-extension",
+      "@jupyterlab/tabmanager-extension",
+      "@jupyterlab/terminal-extension",
+      "@jupyterlab/theme-dark-extension",
+      "@jupyterlab/theme-light-extension",
+      "@jupyterlab/tooltip-extension"
+    ],
+    "mimeExtensions": [
+      "@jupyterlab/json-extension",
+      "@jupyterlab/pdf-extension",
+      "@jupyterlab/vdom-extension",
+      "@jupyterlab/vega2-extension"
+    ]
   }
 }

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -50,9 +50,9 @@ import extensions from './extensions';
 
 
 export
-class Application extends React.Component<Application.Props, Application.State> {
+class Application extends React.Component<Application.IProps, Application.IState> {
 
-    constructor(props: Application.Props) {
+    constructor(props: Application.IProps) {
         super(props);
         this._setLabDir();
         this._preventDefaults();
@@ -62,28 +62,30 @@ class Application extends React.Component<Application.Props, Application.State> 
         this._renderErrorScreen = this._renderErrorScreen.bind(this);
         this._connectionAdded = this._connectionAdded.bind(this);
         this._launchFromPath = this._launchFromPath.bind(this);
-        
-        if (this.props.options.serverState == 'local') {
+
+        if (this.props.options.serverState === 'local') {
             this.state = {renderSplash: this._renderSplash, renderState: this._renderEmpty, remotes: []};
             asyncRemoteRenderer.runRemoteMethod(IServerFactory.requestServerStart, undefined)
                 .then((data) => {
                     this._serverReady(data);
-                })
+                });
         } else {
             this.state = {renderSplash: this._renderEmpty, renderState: this._renderServerManager, remotes: []};
         }
-        
+
         this._serverState = new StateDB({namespace: Application.STATE_NAMESPACE});
         this._serverState.fetch(Application.SERVER_STATE_ID)
             .then((data: Application.IRemoteServerState | null) => {
-                if (!data || !data.remotes)
+                if (!data || !data.remotes) {
                     return;
+                }
                 // Find max connection ID
                 let maxID = 0;
                 for (let val of data.remotes) {
                     // Check validity of server state
-                    if (!val.id || val.id < this._nextRemoteId || !JupyterServer.verifyServer(val))
+                    if (!val.id || val.id < this._nextRemoteId || !JupyterServer.verifyServer(val)) {
                         continue;
+                    }
                     maxID = Math.max(maxID, val.id);
                 }
                 this._nextRemoteId = maxID + 1;
@@ -94,7 +96,7 @@ class Application extends React.Component<Application.Props, Application.State> 
                 console.log(e);
             });
     }
-    
+
     render() {
         let splash = this.state.renderSplash();
         let content = this.state.renderState();
@@ -120,7 +122,7 @@ class Application extends React.Component<Application.Props, Application.State> 
                 factoryId: data.factoryId
             });
         });
-        
+
         this._server = {
             token: data.token,
             url: data.url,
@@ -128,14 +130,14 @@ class Application extends React.Component<Application.Props, Application.State> 
             type: 'local',
         };
 
-        PageConfig.setOption("token", this._server.token);
-        PageConfig.setOption("baseUrl", this._server.url);
+        PageConfig.setOption('token', this._server.token);
+        PageConfig.setOption('baseUrl', this._server.url);
 
-        this._setupLab()
-        
+        this._setupLab();
+
         try {
-            this._lab.start({"ignorePlugins": this._ignorePlugins});
-        } catch(e) {
+            this._lab.start({'ignorePlugins': this._ignorePlugins});
+        } catch (e) {
             console.log(e);
         }
         this._lab.restored.then( () => {
@@ -143,7 +145,7 @@ class Application extends React.Component<Application.Props, Application.State> 
             (this.refs.splash as SplashScreen).fadeSplashScreen();
         });
     }
-    
+
     private _launchFromPath() {
         asyncRemoteRenderer.runRemoteMethod(IServerFactory.requestServerStartPath, undefined)
             .then((data: IServerFactory.IServerStarted) => {
@@ -153,7 +155,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         let pathSelected = () => {
             asyncRemoteRenderer.removeRemoteListener(IServerFactory.pathSelectedEvent, pathSelected);
             this.setState({renderSplash: this._renderSplash, renderState: this._renderEmpty});
-        }
+        };
         asyncRemoteRenderer.onRemoteEvent(IServerFactory.pathSelectedEvent, pathSelected);
     }
 
@@ -163,22 +165,23 @@ class Application extends React.Component<Application.Props, Application.State> 
 
     private _setupLab() {
         let version : string = PageConfig.getOption('appVersion') || 'unknown';
-
-        if (this.props.options.platform == 'win32')
-            PageConfig.setOption('terminalsAvailable', 'false');
-
         if (version[0] === 'v') {
             version = version.slice(1);
+        }
+
+        if (this.props.options.platform === 'win32') {
+            PageConfig.setOption('terminalsAvailable', 'false');
         }
 
         this._lab = new ElectronJupyterLab({
             version: version,
             mimeExtensions: extensions.mime,
-            // disabled: disabled, TODO Implement
-            // deferred: deferred, TODO Implement
+            disabled: extensions.disabled,
+            deferred: extensions.deferred,
             platform: this.props.options.platform,
             uiState: this.props.options.uiState
         });
+        this._ignorePlugins.push(...extensions.ignored);
 
         try {
             this._lab.registerPluginModules(extensions.jupyterlab);
@@ -190,10 +193,10 @@ class Application extends React.Component<Application.Props, Application.State> 
     private _connectionAdded(server: JupyterServer.IServer) {
         PageConfig.setOption('baseUrl', server.url);
         PageConfig.setOption('token', server.token);
-        
+
         try {
-            this._lab.start({"ignorePlugins": this._ignorePlugins});
-        } catch(e) {
+            this._lab.start({'ignorePlugins': this._ignorePlugins});
+        } catch (e) {
             console.log(e);
         }
 
@@ -222,7 +225,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         return (
             <div className='jpe-content'>
                 <SplashScreen  ref='splash' uiState={this.props.options.uiState} finished={() => {
-                    this.setState({renderSplash: this._renderEmpty});}
+                    this.setState({renderSplash: this._renderEmpty}); }
                 } />
             </div>
         );
@@ -234,7 +237,7 @@ class Application extends React.Component<Application.Props, Application.State> 
                 <TitleBar uiState={this.props.options.uiState} />
                 <ServerError launchFromPath={this._launchFromPath}/>
             </div>
-        )
+        );
     }
 
     private _renderEmpty(): JSX.Element {
@@ -260,7 +263,7 @@ class Application extends React.Component<Application.Props, Application.State> 
         document.ondrop = (event: DragEvent) => {
             event.preventDefault();
             let files = event.dataTransfer.files;
-            for (let i = 0; i < files.length; i ++){
+            for (let i = 0; i < files.length; i ++) {
                 this._openFile(files[i].path);
             }
         };
@@ -268,16 +271,16 @@ class Application extends React.Component<Application.Props, Application.State> 
         asyncRemoteRenderer.onRemoteEvent(ISessions.openFileEvent, this._openFile);
     }
 
-    private _openFile(path: string){
-        if (this._labDir){
+    private _openFile(path: string) {
+        if (this._labDir) {
             let relPath = path.replace(this._labDir, '');
             let winConvert = relPath.split('\\').join('/');
-            relPath = winConvert.replace("/", "");
+            relPath = winConvert.replace('/', '');
             this._lab.commands.execute('docmanager:open', {path: relPath});
         }
     }
 
-    private _setLabDir(){
+    private _setLabDir() {
         this._labDir = remote.app.getPath('home');
     }
 
@@ -290,15 +293,15 @@ class Application extends React.Component<Application.Props, Application.State> 
     private _server: JupyterServer.IServer = null;
 
     private _nextRemoteId: number = 1;
-    
+
     private _serverState: StateDB;
 
     // private _labReady: Promise<void>;
 }
 
-export 
+export
 namespace Application {
-    
+
     /**
      * Namspace for server manager state stored in StateDB
      */
@@ -312,12 +315,12 @@ namespace Application {
     const SERVER_STATE_ID = 'servers';
 
     export
-    interface Props {
+    interface IProps {
         options: JupyterLabSession.IInfo;
     }
 
     export
-    interface State {
+    interface IState {
         renderState: () => any;
         renderSplash: () => any;
         remotes: IRemoteServer[];

--- a/src/browser/extensions/electron-extension/index.ts
+++ b/src/browser/extensions/electron-extension/index.ts
@@ -61,8 +61,7 @@ namespace CommandIDs {
 
   export
   const toggleMode: string = 'main-jupyterlab:toggle-mode';
-};
-
+}
 
 
 export
@@ -71,17 +70,17 @@ class ElectronJupyterLab extends JupyterLab {
   constructor(options: ElectronJupyterLab.IOptions) {
     /**
      * WORKAROUND
-     * The constructor of JupyterLab in @jupyterlab/application initializes 
-     * the ServiceManager with the default options. The default options 
+     * The constructor of JupyterLab in @jupyterlab/application initializes
+     * the ServiceManager with the default options. The default options
      * include the baseUrl and token at the moment when the application starts
-     * without an option to override them. JupyterLab_app starts the server 
-     * and sets the relevant config data at runtime, so the default settings 
-     * no longer work. Therefore overriding the default options is the only 
+     * without an option to override them. JupyterLab_app starts the server
+     * and sets the relevant config data at runtime, so the default settings
+     * no longer work. Therefore overriding the default options is the only
      * solution at the moment.
-     * 
+     *
      * @jupyterlab/application 0.15.4
      */
-    const oldMakeSettings = ServerConnection.makeSettings
+    const oldMakeSettings = ServerConnection.makeSettings;
     ServerConnection.makeSettings = function(options?: Partial<ServerConnection.ISettings>) {
       options = {
         ...options,
@@ -92,9 +91,9 @@ class ElectronJupyterLab extends JupyterLab {
           token: PageConfig.getToken()
         }
       };
-      return oldMakeSettings(options)
-    }
-    
+      return oldMakeSettings(options);
+    };
+
     super(options);
 
     this._electronInfo = { ...JupyterLab.defaultInfo, ...options };
@@ -105,14 +104,14 @@ class ElectronJupyterLab extends JupyterLab {
     // Get the top panel widget
     let topPanel: Widget;
     each(this.shell.layout.iter(), (widget: Widget) => {
-      if (widget.id == 'jp-top-panel') {
+      if (widget.id === 'jp-top-panel') {
         topPanel = widget;
         return false;
       }
     });
     topPanel.addClass('jpe-mod-' + options.uiState);
-    
-    if (options.uiState == 'mac') {
+
+    if (options.uiState === 'mac') {
       // Resize the top panel based on zoom factor
       topPanel.node.style.minHeight = topPanel.node.style.height = String(Browser.getTopPanelSize()) + 'px';
       // Resize the top panel on zoom events
@@ -131,7 +130,7 @@ class ElectronJupyterLab extends JupyterLab {
    * The service manager used by the application.
    */
   readonly serviceManager: ServiceManager;
-  
+
   private _electronInfo: ElectronJupyterLab.IInfo;
 }
 
@@ -231,8 +230,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
  * Override default jupyterlab plugins
  */
 let nPlugins = plugins.map((p: JupyterLabPlugin<any>) => {
-    if (p.id == 'jupyter.extensions.main')
-        return mainPlugin;
+    if (p.id === 'jupyter.extensions.main') {
+      return mainPlugin;
+    }
     return p;
 });
 export default nPlugins;

--- a/src/browser/extensions/index.ts
+++ b/src/browser/extensions/index.ts
@@ -1,41 +1,137 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-let jupyterlab = [
-    require("./electron-extension"),
-    require("./utils-extension"),
-    require("@jupyterlab/codemirror-extension"),
-    require("@jupyterlab/completer-extension"),
-    require("@jupyterlab/console-extension"),
-    require("@jupyterlab/csvviewer-extension"),
-    require("@jupyterlab/docmanager-extension"),
-    require("@jupyterlab/faq-extension"),
-    require("@jupyterlab/filebrowser-extension"),
-    require("@jupyterlab/fileeditor-extension"),
-    require("@jupyterlab/help-extension"),
-    require("@jupyterlab/imageviewer-extension"),
-    require("@jupyterlab/inspector-extension"),
-    require("@jupyterlab/launcher-extension"),
-    require("@jupyterlab/mainmenu-extension"),
-    require("@jupyterlab/markdownviewer-extension"),
-    require("@jupyterlab/mathjax2-extension"),
-    require("@jupyterlab/notebook-extension"),
-    require("@jupyterlab/rendermime-extension"),
-    require("@jupyterlab/running-extension"),
-    require("@jupyterlab/settingeditor-extension"),
-    require("@jupyterlab/shortcuts-extension"),
-    require("@jupyterlab/tabmanager-extension"),
-    require("@jupyterlab/terminal-extension"),
-    require("@jupyterlab/theme-dark-extension"),
-    require("@jupyterlab/theme-light-extension"),
-    require("@jupyterlab/tooltip-extension")
-];
+import {
+    PageConfig
+} from '@jupyterlab/coreutils';
 
-let mime = [
-    require("@jupyterlab/json-extension"),
-    require("@jupyterlab/pdf-extension"),
-    require("@jupyterlab/vdom-extension"),
-    require("@jupyterlab/vega2-extension")
-];
+const extensions: any = {
+    './electron-extension': require('./electron-extension'),
+    './utils-extension': require('./utils-extension'),
+    '@jupyterlab/codemirror-extension': require('@jupyterlab/codemirror-extension'),
+    '@jupyterlab/completer-extension': require('@jupyterlab/completer-extension'),
+    '@jupyterlab/console-extension': require('@jupyterlab/console-extension'),
+    '@jupyterlab/csvviewer-extension': require('@jupyterlab/csvviewer-extension'),
+    '@jupyterlab/docmanager-extension': require('@jupyterlab/docmanager-extension'),
+    '@jupyterlab/faq-extension': require('@jupyterlab/faq-extension'),
+    '@jupyterlab/filebrowser-extension': require('@jupyterlab/filebrowser-extension'),
+    '@jupyterlab/fileeditor-extension': require('@jupyterlab/fileeditor-extension'),
+    '@jupyterlab/help-extension': require('@jupyterlab/help-extension'),
+    '@jupyterlab/imageviewer-extension': require('@jupyterlab/imageviewer-extension'),
+    '@jupyterlab/inspector-extension': require('@jupyterlab/inspector-extension'),
+    '@jupyterlab/launcher-extension': require('@jupyterlab/launcher-extension'),
+    '@jupyterlab/mainmenu-extension': require('@jupyterlab/mainmenu-extension'),
+    '@jupyterlab/markdownviewer-extension': require('@jupyterlab/markdownviewer-extension'),
+    '@jupyterlab/mathjax2-extension': require('@jupyterlab/mathjax2-extension'),
+    '@jupyterlab/notebook-extension': require('@jupyterlab/notebook-extension'),
+    '@jupyterlab/rendermime-extension': require('@jupyterlab/rendermime-extension'),
+    '@jupyterlab/running-extension': require('@jupyterlab/running-extension'),
+    '@jupyterlab/settingeditor-extension': require('@jupyterlab/settingeditor-extension'),
+    '@jupyterlab/shortcuts-extension': require('@jupyterlab/shortcuts-extension'),
+    '@jupyterlab/tabmanager-extension': require('@jupyterlab/tabmanager-extension'),
+    '@jupyterlab/terminal-extension': require('@jupyterlab/terminal-extension'),
+    '@jupyterlab/theme-dark-extension': require('@jupyterlab/theme-dark-extension'),
+    '@jupyterlab/theme-light-extension': require('@jupyterlab/theme-light-extension'),
+    '@jupyterlab/tooltip-extension': require('@jupyterlab/tooltip-extension'),
+    '@jupyterlab/json-extension': require('@jupyterlab/json-extension'),
+    '@jupyterlab/pdf-extension': require('@jupyterlab/pdf-extension'),
+    '@jupyterlab/vdom-extension': require('@jupyterlab/vdom-extension'),
+    '@jupyterlab/vega2-extension': require('@jupyterlab/vega2-extension')
+} as { [key: string]: any };
 
-export default {jupyterlab, mime};
+// tslint:disable-next-line:no-var-requires
+const jlab = require('../../../../package.json').jupyterlab;
+
+const disabled = { patterns: [] as string[], matches: [] as string[] };
+const deferred = { patterns: [] as string[], matches: [] as string[] };
+const ignored: string[] = [];
+
+// Get the disabled extensions.
+let disabledExtensions: IExtensionPattern[] = [];
+try {
+    const tempDisabled = PageConfig.getOption('disabledExtensions');
+    if (tempDisabled) {
+        disabledExtensions = JSON.parse(tempDisabled).map(function (pattern: string) {
+            disabled.patterns.push(pattern);
+            return { raw: pattern, rule: new RegExp(pattern) };
+        });
+    }
+} catch (error) {
+    console.warn('Unable to parse disabled extensions.', error);
+}
+
+// Get the deferred extensions.
+let deferredExtensions: IExtensionPattern[] = [];
+try {
+    const tempDeferred = PageConfig.getOption('deferredExtensions');
+    if (tempDeferred) {
+        deferredExtensions = JSON.parse(tempDeferred).map(function (pattern: string) {
+            deferred.patterns.push(pattern);
+            return { raw: pattern, rule: new RegExp(pattern) };
+        });
+    }
+} catch (error) {
+    console.warn('Unable to parse deferred extensions.', error);
+}
+
+function isDeferred(value: string) {
+    return deferredExtensions.some(function (pattern) {
+        return pattern.raw === value || pattern.rule.test(value);
+    });
+}
+
+function isDisabled(value: string) {
+    return disabledExtensions.some(function (pattern) {
+        return pattern.raw === value || pattern.rule.test(value);
+    });
+}
+
+function loadExtensions(extensionNames: string[]): any[] {
+    const enabled: any[] = [];
+    for (const extensionName of extensionNames) {
+        try {
+            if (isDeferred(extensionName)) {
+                deferred.matches.push(extensionName);
+                ignored.push(extensionName);
+            }
+            if (isDisabled(extensionName)) {
+                disabled.matches.push(extensionName);
+            } else {
+                const extension = extensions[extensionName];
+                if (!extension) {
+                    console.log(extensionName + ' not found');
+                    continue;
+                }
+
+                if (Array.isArray(extension)) {
+                    extension.forEach(function (plugin) {
+                        if (isDeferred(plugin.id)) {
+                            deferred.matches.push(plugin.id);
+                            ignored.push(plugin.id);
+                        }
+                        if (isDisabled(plugin.id)) {
+                            disabled.matches.push(plugin.id);
+                            return;
+                        }
+                        enabled.push(plugin);
+                    });
+                } else {
+                    enabled.push(extension);
+                }
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+    return enabled;
+}
+
+const jupyterlab = loadExtensions(jlab.extensions);
+const mime = loadExtensions(jlab.mimeExtensions);
+
+export default { jupyterlab, mime, disabled, deferred, ignored };
+
+interface IExtensionPattern {
+    raw: string;
+    rule: RegExp;
+}

--- a/src/browser/extensions/utils-extension/index.tsx
+++ b/src/browser/extensions/utils-extension/index.tsx
@@ -68,7 +68,7 @@ namespace CommandIDs {
     const connectToServer = 'electron-jupyterlab:connect-to-server';
 }
 
-interface ServerManagerMenuArgs extends JSONObject {
+interface IServerManagerMenuArgs extends JSONObject {
     name: string;
     type: 'local' | 'remote';
     remoteServerId?: number;
@@ -80,7 +80,7 @@ const serverManagerPlugin: JupyterLabPlugin<void> = {
     activate: (app: ElectronJupyterLab, palette: ICommandPalette, menu: IMainMenu) => {
     let serverState = new StateDB({namespace: Application.STATE_NAMESPACE});
     // Insert a local server
-    let servers: ServerManagerMenuArgs[] = [{name: 'Local', type: 'local'}];
+    let servers: IServerManagerMenuArgs[] = [{name: 'Local', type: 'local'}];
 
     serverState.fetch(Application.SERVER_STATE_ID)
         .then((data: Application.IRemoteServerState | null) => {
@@ -92,7 +92,7 @@ const serverManagerPlugin: JupyterLabPlugin<void> = {
                         type: 'remote',
                         name: remote.name,
                         id: remote.id
-                    } as ServerManagerMenuArgs;
+                    } as IServerManagerMenuArgs;
                 }));
                 createServerManager(app, palette, menu, servers);
             }
@@ -106,10 +106,10 @@ const serverManagerPlugin: JupyterLabPlugin<void> = {
     return null;
   },
   autoStart: true
-}
+};
 
 function createServerManager(app: ElectronJupyterLab, palette: ICommandPalette,
-                            menu: IMainMenu, servers: ServerManagerMenuArgs[]) {
+                             menu: IMainMenu, servers: IServerManagerMenuArgs[]) {
     app.commands.addCommand(CommandIDs.activateServerManager, {
         label: 'Add Server',
         execute: () => {
@@ -120,7 +120,7 @@ function createServerManager(app: ElectronJupyterLab, palette: ICommandPalette,
     });
     app.commands.addCommand(CommandIDs.connectToServer, {
         label: (args) => args.name as string,
-        execute: (args: ServerManagerMenuArgs) => {
+        execute: (args: IServerManagerMenuArgs) => {
             asyncRemoteRenderer.runRemoteMethod(ISessions.createSession, {
                 state: args.type,
                 remoteServerId: args.remoteServerId
@@ -251,10 +251,11 @@ const settingPlugin: JupyterLabPlugin<ISettingRegistry> = {
  * Override Main Menu plugin from apputils-extension
  */
 let nPlugins = plugins.map((p: JupyterLabPlugin<any>) => {
-    if (p.id == 'jupyter.services.main-menu')
+    if (p.id == 'jupyter.services.main-menu') {
         return nativeMainMenuPlugin;
-    else if (p.id == 'jupyter.services.setting-registry')
+    } else if (p.id == 'jupyter.services.setting-registry') {
         return settingPlugin;
+    }
     return p;
 });
 nPlugins.push(serverManagerPlugin);

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import './require';
 import 'font-awesome/css/font-awesome.min.css';
 import './style/main.css';
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import * as Bottle from 'bottlejs';
  * Require debugging tools. Only
  * runs when in development.
  */
+// tslint:disable-next-line:no-var-requires
 require('electron-debug')({showDevTools: false});
 
 /**
@@ -33,7 +34,7 @@ interface IService {
     /**
      * A function to create the service object.
      */
-    activate: (...any: any[]) => any;
+    activate: (...x: any[]) => any;
 
     /**
      * Whether the service should be instantiated immediatelty,
@@ -45,15 +46,10 @@ interface IService {
 /**
  * Servies required by this application.
  */
-let services: IService[] = [
-    require('./app').default,
-    require('./sessions').default,
-    require('./server').default,
-    require('./menu').default,
-    require('./shortcuts').default,
-    require('./utils').default,
-    require('./registry').default,
-];
+const services = ['./app', './sessions', './server', './menu', './shortcuts', './utils', './registry']
+.map((service: string) => {
+    return require(service).default;
+});
 
 /**
  * Load all services when the electron app is


### PR DESCRIPTION
The list of core extensions is still hardcoded in the code, but fully dynamic module loading is not possible. The solution of the main JupyterLab package is automatically rewriting the startup script to import the relevant modules before webpack does its work. This solution will not do here since the relevant file is written in typescript which means that the file cannot contain template information. Typescript does not like that.

This will probably change anyway before JLab 1.0, so I guess we do not have to worry about it too much.