### PR TITLE
Fix macosx env inheritance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,6 +2670,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw="
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -3757,6 +3762,14 @@
             "path-is-absolute": "1.0.1"
           }
         }
+      }
+    },
+    "fix-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-2.1.0.tgz",
+      "integrity": "sha1-cuznOd6a9L1j/QLaI+mnDGGbTDg=",
+      "requires": {
+        "shell-path": "2.1.0"
       }
     },
     "flatten": {
@@ -5798,7 +5811,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -6111,7 +6123,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -6235,8 +6246,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -6358,8 +6368,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -7193,8 +7202,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "public-encrypt": {
       "version": "4.0.0",
@@ -7863,6 +7871,58 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-env": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-0.3.0.tgz",
+      "integrity": "sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=",
+      "requires": {
+        "default-shell": "1.0.1",
+        "execa": "0.5.1",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
+    "shell-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-2.1.0.tgz",
+      "integrity": "sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=",
+      "requires": {
+        "shell-env": "0.3.0"
+      }
+    },
     "shelljs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
@@ -7871,8 +7931,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "single-line-log": {
       "version": "1.1.2",
@@ -8128,8 +8187,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -9184,8 +9242,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "bottlejs": "^1.6.1",
     "electron-debug": "^1.2.0",
     "es6-promise": "^4.1.1",
+    "fix-path": "^2.1.0",
     "font-awesome": "^4.7.0",
     "jshint": "^2.9.5",
     "react": "~16.2.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,8 +11,13 @@ import * as Bottle from 'bottlejs';
 // tslint:disable-next-line:no-var-requires
 require('electron-debug')({showDevTools: false});
 
-const fixPath = require('fix-path');
-fixPath();
+/**
+ * On Mac OSX the PATH env variable a packaged app gets does not
+ * contain all the information that is usually set in .bashrc, .bash_profile, etc.
+ * This package fixes the PATH variable
+ */
+require('fix-path')();
+
 /**
  * A user-defined service.
  *

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,8 @@ import * as Bottle from 'bottlejs';
 // tslint:disable-next-line:no-var-requires
 require('electron-debug')({showDevTools: false});
 
+const fixPath = require('fix-path');
+fixPath();
 /**
  * A user-defined service.
  *


### PR DESCRIPTION
Fix issue where on Mac OSX user environment variables from dot files (`.bashrc`, `.bash_profile`, etc.) where not being added to overall `PATH` variable. This meant that user's `python` and `jupyter` executable instances were not being discovered by the registry.

Provides possible fix for https://github.com/jupyterlab/jupyterlab_app/issues/148