### PR TITLE
Expand debug output

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@types/react": "~16.0.19",
     "@types/react-dom": "^16.0.4",
     "@types/semver": "^5.4.0",
+    "@types/yargs": "^11.0.0",
     "bottlejs": "^1.6.1",
     "electron-debug": "^1.2.0",
     "electron-log": "^2.2.14",
@@ -191,7 +192,8 @@
     "semver": "^5.4.1",
     "which": "^1.3.0",
     "winreg": "^1.2.4",
-    "xterm": "^3.0.2"
+    "xterm": "^3.0.2",
+    "yargs": "^11.0.0"
   },
   "resolutions": {
     "@types/react-dom/@types/react": "~16.0.19"

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
     "watch:pack": "webpack --progress --colors --watch --config webpack.browser.js",
     "watch:tsc": "tsc -w",
     "watch:assets": "node ./scripts/extract.js && node ./scripts/copyassets.js watch",
-    "watch": "concurrently \"npm run watch:tsc\" \"npm run watch:assets\" \"npm run watch:pack\" ",
+    "watch": "concurrently \"yarn watch:tsc\" \"yarn watch:assets\" \"yarn watch:pack\" ",
     "build:pack": "webpack --config webpack.browser.js",
-    "build": "tsc && node ./scripts/extract.js && node ./scripts/copyassets.js && npm run build:pack",
-    "build:all": "npm run build && npm start",
+    "build": "tsc && node ./scripts/extract.js && node ./scripts/copyassets.js && yarn build:pack",
+    "build:all": "yarn build && yarn start",
     "extract": "node scripts/extract.js",
-    "pack": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder",
-    "dist:linux": "npm run build && electron-builder --linux",
+    "pack": "yarn build && electron-builder --dir",
+    "dist": "yarn build && electron-builder",
+    "dist:linux": "yarn build && electron-builder --linux",
     "dockerdist:linux": "docker run --rm -ti -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c \"yarn && yarn dist:linux\"",
-    "dist:mac": "npm run build && electron-builder --macos",
-    "dist:win": "npm run build && electron-builder --win",
+    "dist:mac": "yarn build && electron-builder --macos",
+    "dist:win": "yarn build && electron-builder --win",
     "dockerdist:win": "docker run --rm -ti -v ${PWD}:/project -v ${PWD##*/}-node-modules:/project/node_modules -v ~/.electron:/root/.electron electronuserland/electron-builder:wine /bin/bash -c \"yarn && yarn dist:win\"",
     "release": "electron-builder --publish onTagOrDraft"
   },
@@ -49,7 +49,7 @@
         "AppImage"
       ],
       "desktop": {
-        "Categories":  "Science;Development;"
+        "Categories": "Science;Development;"
       }
     },
     "win": {

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -15,6 +15,13 @@ import {
     JupyterLabSession
 } from '../main/sessions';
 
+import log from 'electron-log';
+
+console.log = log.log;
+console.error = log.error;
+console.warn = log.warn;
+console.info = log.info;
+console.debug = log.debug;
 
 /**
  * HACK

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -73,8 +73,8 @@ console.debug = log.debug;
  * A user-defined service.
  *
  * Services make up the core functionality of the
- * application. Each service is istatntiated
- * once and then becomes available to every other serivce.
+ * application. Each service is instantiated
+ * once and then becomes available to every other service.
  */
 export
 interface IService {
@@ -95,14 +95,14 @@ interface IService {
     activate: (...x: any[]) => any;
 
     /**
-     * Whether the service should be instantiated immediatelty,
+     * Whether the service should be instantiated immediately,
      * or lazy loaded.
      */
     autostart?: boolean;
 }
 
 /**
- * Servies required by this application.
+ * Services required by this application.
  */
 const services = ['./app', './sessions', './server', './menu', './shortcuts', './utils', './registry']
 .map((service: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,10 @@
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
 
+"@types/yargs@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-11.0.0.tgz#124b9ed9c65b7091cc36da59ae12cbd47d8745ea"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
This PR expands the amount of debug output displayed to the console by routing the render console output to the terminal.

It also adds CLI options that specify the desired level of output using the `-v` option flag. Multiple occurrences of the flag lead to more debug output.

Resolves issue raised in #110.