### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,26 @@ jobs:
             return releaseWithTag ? 'true' : 'false'
           result-encoding: string
 
+      - name: Upload Debian Installer as Release asset
+        if: matrix.cfg.platform == 'linux' && steps.release-exists.outputs.result == 'true'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.JLAB_APP_TOKEN }}
+          file: dist/JupyterLab.deb
+          asset_name: JupyterLab-Setup-Debian.deb
+          tag: v${{ steps.package-info.outputs.version}}
+          overwrite: true
+
+      - name: Upload Fedora Installer as Release asset
+        if: matrix.cfg.platform == 'linux' && steps.release-exists.outputs.result == 'true'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.JLAB_APP_TOKEN }}
+          file: dist/JupyterLab.rpm
+          asset_name: JupyterLab-Setup-Fedora.rpm
+          tag: v${{ steps.package-info.outputs.version}}
+          overwrite: true
+
       - name: Upload macOS Installer as Release asset
         if: matrix.cfg.platform == 'mac' && steps.release-exists.outputs.result == 'true'
         uses: svenstaro/upload-release-action@v2
@@ -121,5 +141,15 @@ jobs:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab.pkg
           asset_name: JupyterLab-Setup-macOS.pkg
+          tag: v${{ steps.package-info.outputs.version}}
+          overwrite: true
+
+      - name: Upload Windows Installer as Release asset
+        if: matrix.cfg.platform == 'win' && steps.release-exists.outputs.result == 'true'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.JLAB_APP_TOKEN }}
+          file: dist/JupyterLab-Setup.exe
+          asset_name: JupyterLab-Setup-Windows.exe
           tag: v${{ steps.package-info.outputs.version}}
           overwrite: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,85 +14,85 @@ jobs:
     strategy:
       matrix:
         cfg:
-        # - { platform: linux, platform_name: Linux,  os: ubuntu-latest }
+        - { platform: linux, platform_name: Linux,  os: ubuntu-latest }
         - { platform: mac, platform_name: macOS, os: macos-latest }
-        # - { platform: win, platform_name: Windows, os: windows-latest }
-        
+        - { platform: win, platform_name: Windows, os: windows-latest }
+
     name: '${{ matrix.cfg.platform_name }} installer'
     runs-on: ${{ matrix.cfg.os }}
 
     steps:
       - uses: actions/checkout@v2
-      # - uses: s-weigand/setup-conda@v1
+      - uses: s-weigand/setup-conda@v1
 
-      # - name: Install node
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: '14.x'
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
 
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - name: Cache yarn
-      #   uses: actions/cache@v2
-      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-
 
-      # - name: Install dependencies
-      #   run: |
-      #     npm install --global yarn
-      #     # conda install constructor
-      #     yarn install
+      - name: Install dependencies
+        run: |
+          npm install --global yarn
+          # conda install constructor
+          yarn install
 
-      # # - name: Create App Server Installer
-      # #   run: |
-      # #     yarn create_env_installer:${{ matrix.cfg.platform }}
+      - name: Create App Server Installer
+        run: |
+          yarn create_env_installer:${{ matrix.cfg.platform }}
 
-      # - name: Create App Installer
-      #   run: |
-      #     yarn dist:${{ matrix.cfg.platform }}
+      - name: Create App Installer
+        run: |
+          yarn dist:${{ matrix.cfg.platform }}
 
-      # - name: Upload Debian Installer
-      #   if: matrix.cfg.platform == 'linux'
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: debian-installer
-      #     path: |
-      #       dist/JupyterLab.deb
+      - name: Upload Debian Installer
+        if: matrix.cfg.platform == 'linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: debian-installer
+          path: |
+            dist/JupyterLab.deb
 
-      # - name: Upload Fedora Installer
-      #   if: matrix.cfg.platform == 'linux'
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: fedora-installer
-      #     path: |
-      #       dist/JupyterLab.rpm
+      - name: Upload Fedora Installer
+        if: matrix.cfg.platform == 'linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: fedora-installer
+          path: |
+            dist/JupyterLab.rpm
 
-      # - name: Upload macOS Installer
-      #   if: matrix.cfg.platform == 'mac'
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: mac-installer
-      #     path: |
-      #       dist/JupyterLab.pkg
+      - name: Upload macOS Installer
+        if: matrix.cfg.platform == 'mac'
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac-installer
+          path: |
+            dist/JupyterLab.pkg
 
-      # - name: Upload Windows Installer
-      #   if: matrix.cfg.platform == 'win'
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: windows-installer
-      #     path: |
-      #       dist/JupyterLab-Setup.exe
+      - name: Upload Windows Installer
+        if: matrix.cfg.platform == 'win'
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-installer
+          path: |
+            dist/JupyterLab-Setup.exe
 
       - name: Get package info
         id: package-info
         uses: codex-team/action-nodejs-package-info@v1
 
-      - name: Get release info
+      - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
         uses: actions/github-script@v4
         id: release-exists
         env:
@@ -110,12 +110,12 @@ jobs:
             return releaseWithTag ? 'true' : 'false'
           result-encoding: string
 
-      - name: Upload macOS Installer release asset
+      - name: Upload macOS Installer as Release asset
         if: matrix.cfg.platform == 'mac' && steps.release-exists.outputs.result == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
-          file: package.json
-          asset_name: package.json
+          file: dist/JupyterLab.pkg
+          asset_name: JupyterLab-Setup-macOS.pkg
           tag: v${{ steps.package-info.outputs.version}}
           overwrite: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,76 +14,108 @@ jobs:
     strategy:
       matrix:
         cfg:
-        - { platform: linux, platform_name: Linux,  os: ubuntu-latest }
+        # - { platform: linux, platform_name: Linux,  os: ubuntu-latest }
         - { platform: mac, platform_name: macOS, os: macos-latest }
-        - { platform: win, platform_name: Windows, os: windows-latest }
+        # - { platform: win, platform_name: Windows, os: windows-latest }
         
     name: '${{ matrix.cfg.platform_name }} installer'
     runs-on: ${{ matrix.cfg.os }}
 
     steps:
       - uses: actions/checkout@v2
-      - uses: s-weigand/setup-conda@v1
+      # - uses: s-weigand/setup-conda@v1
 
-      - name: Install node
-        uses: actions/setup-node@v2
+      # - name: Install node
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: '14.x'
+
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - name: Cache yarn
+      #   uses: actions/cache@v2
+      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-
+
+      # - name: Install dependencies
+      #   run: |
+      #     npm install --global yarn
+      #     # conda install constructor
+      #     yarn install
+
+      # # - name: Create App Server Installer
+      # #   run: |
+      # #     yarn create_env_installer:${{ matrix.cfg.platform }}
+
+      # - name: Create App Installer
+      #   run: |
+      #     yarn dist:${{ matrix.cfg.platform }}
+
+      # - name: Upload Debian Installer
+      #   if: matrix.cfg.platform == 'linux'
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: debian-installer
+      #     path: |
+      #       dist/JupyterLab.deb
+
+      # - name: Upload Fedora Installer
+      #   if: matrix.cfg.platform == 'linux'
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: fedora-installer
+      #     path: |
+      #       dist/JupyterLab.rpm
+
+      # - name: Upload macOS Installer
+      #   if: matrix.cfg.platform == 'mac'
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: mac-installer
+      #     path: |
+      #       dist/JupyterLab.pkg
+
+      # - name: Upload Windows Installer
+      #   if: matrix.cfg.platform == 'win'
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: windows-installer
+      #     path: |
+      #       dist/JupyterLab-Setup.exe
+
+      - name: Get package info
+        id: package-info
+        uses: codex-team/action-nodejs-package-info@v1
+
+      - name: Get release info
+        uses: actions/github-script@v4
+        id: release-exists
+        env:
+          APP_VERSION: ${{ steps.package-info.outputs.version}}
         with:
-          node-version: '14.x'
+          script: |
+            const releases = await github.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            const tagName = `v${process.env.APP_VERSION}`
+            console.log('tagName', tagName, 'owner', context.repo.owner, 'repo', context.repo.repo)
+            console.log(`releases`, releases)
+            const releaseWithTag = releases.data.find(release => release.tag_name === tagName && (release.draft || release.prerelease))
+            return releaseWithTag ? 'true' : 'false'
+          result-encoding: string
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache yarn
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Upload macOS Installer release asset
+        if: matrix.cfg.platform == 'mac' && steps.release-exists.outputs.result == 'true'
+        uses: svenstaro/upload-release-action@v2
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-
-
-      - name: Install dependencies
-        run: |
-          npm install --global yarn
-          conda install constructor
-          yarn install
-
-      - name: Create App Server Installer
-        run: |
-          yarn create_env_installer:${{ matrix.cfg.platform }}
-
-      - name: Create App Installer
-        run: |
-          yarn dist:${{ matrix.cfg.platform }}
-
-      - name: Upload Debian Installer
-        if: matrix.cfg.platform == 'linux'
-        uses: actions/upload-artifact@v2
-        with:
-          name: debian-installer
-          path: |
-            dist/JupyterLab.deb
-
-      - name: Upload Fedora Installer
-        if: matrix.cfg.platform == 'linux'
-        uses: actions/upload-artifact@v2
-        with:
-          name: fedora-installer
-          path: |
-            dist/JupyterLab.rpm
-
-      - name: Upload macOS Installer
-        if: matrix.cfg.platform == 'mac'
-        uses: actions/upload-artifact@v2
-        with:
-          name: mac-installer
-          path: |
-            dist/JupyterLab.pkg
-
-      - name: Upload Windows Installer
-        if: matrix.cfg.platform == 'win'
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows-installer
-          path: |
-            dist/JupyterLab-Setup.exe
+          repo_token: ${{ secrets.JLAB_APP_TOKEN }}
+          file: package.json
+          asset_name: package.json
+          tag: v${{ steps.package-info.outputs.version}}
+          overwrite: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,8 +108,6 @@ jobs:
               repo: context.repo.repo
             })
             const tagName = `v${process.env.APP_VERSION}`
-            console.log('tagName', tagName, 'owner', context.repo.owner, 'repo', context.repo.repo)
-            console.log(`releases`, releases)
             const releaseWithTag = releases.data.find(release => release.tag_name === tagName && (release.draft || release.prerelease))
             return releaseWithTag ? 'true' : 'false'
           result-encoding: string

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,12 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn
-          # conda install constructor
+          conda install constructor
           yarn install
+
+      - name: Check JupyterLab version match
+        run: |
+          yarn check_version_match
 
       - name: Create App Server Installer
         run: |

--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ JupyterLab App bundles JupyterLab front-end and a conda environment as JupyterLa
     ```
 
     App Installer will be created in `dist/JupyterLab.pkg` (macOS), `dist/JupyterLab.deb` (Debian, Ubuntu), `dist/JupyterLab.rpm` (Red Hat, Fedora) and `dist/JupyterLab-Setup.exe` (Windows) based on the platform
+
+## Release Instructions
+
+For instructions on updating bundled JupyterLab packages and cutting a new release, please follow [release.md](release.md) document.

--- a/Release.md
+++ b/Release.md
@@ -42,8 +42,8 @@ In order to change the JupyterLab version bundled with the App:
 
     tbump will list changes to be applied, confirm the changes to proceed with apply.
 
-2. Create a commit with the version changes and create a PR. The PR must be created from main repo and not from a fork. This is necessary for GitHub Actions to be able to attach installers to the release.
+3. Create a commit with the version changes and create a PR. The PR must be created from main repo and not from a fork. This is necessary for GitHub Actions to be able to attach installers to the release.
 
-3. GitHub Actions will automatically create installers for each platform (Linux, macOS, Windows) and upload them as release assets. Assets will be uploaded only if a release of type `draft` or `pre-release` with tag matching the JupyterLab App's version with a `v` prefix is found. For example, if the JupyterLab App version in the PR is `3.1.12-2`, the installers will be uploaded to a release that is flagged as `draft` or `pre-release` and has a tag `v3.1.12-2`. New commits to PR will overwrite the installer assets of the release.
+4. GitHub Actions will automatically create installers for each platform (Linux, macOS, Windows) and upload them as release assets. Assets will be uploaded only if a release of type `draft` or `pre-release` with tag matching the JupyterLab App's version with a `v` prefix is found. For example, if the JupyterLab App version in the PR is `3.1.12-2`, the installers will be uploaded to a release that is flagged as `draft` or `pre-release` and has a tag `v3.1.12-2`. New commits to PR will overwrite the installer assets of the release.
 
-4. Once all the changes are complete, and installers are uploaded to the release then publish the release.
+5. Once all the changes are complete, and installers are uploaded to the release then publish the release.

--- a/Release.md
+++ b/Release.md
@@ -1,23 +1,49 @@
-# Releasing through Travis-CI
+# Release Instructions
 
-### Workflow 1
+## Dependencies
 
-1. Draft a new release on Github. Set the "Tag version" to the value of version in your application package.json, and prefix it with v. "Release title" can be anything you want.
-For example, if your application package.json version is 1.0, your draft's "Tag version" would be v1.0.
-2. Push some commits. Every CI build will update the artifacts attached to this draft.
-3. Once you are done, publish the release. GitHub will tag the latest commit for you.
+JupyterLab App uses [tbump](https://github.com/dmerejkowsky/tbump) to bump JupyterLab and app versions. You can install using:
+```bash
+pip install tbump
+```
 
-The benefit of this workflow is that it allows you to always have the latest artifacts, and the release can be published once it is ready.
+## Versioning
 
-### Workflow 2
+JupyterLab App needs to be versioned with the same major, minor and patch versions as the JupyterLab it bundles. For example, if JupyterLab App is based on JupyterLab 3.1.12, a valid JupyterLab App version is 3.1.12-1 to 3.1.12-n. Last number after `-` is used as the `build number`. This version matching is enforced before JupyterLab App installer binaries are published.
 
-1. run `npm version major/minor/patch` to tag and generate a commit
-2. push the commit and the tag
-3. The CI will draft a release with the correct "Tag version" from your package.json file
+JupyterLab version, that JupyterLab App bundles, is determined by `@jupyterlab/metapackage` dependency version in the [yarn.lock](yarn.lock).
+
+If the JupyterLab version is not changing with the new JupyterLab App release then only increment the build number after `-` (for example `3.1.12-2` to `3.1.12-3`). However, if JupyterLab version is changing with the new JupyterLab App release then reset the build number after `-` to 1 (for example `3.1.12-3` to `3.1.13-1`).
 
 
-# Dependencies
+## Updating the bundled JupyterLab
 
-To build for Linux and Windows the suggested way is to use the `dockerdist:linux` and `dockerdist:windows` command that use a well-tested and fully equipped docker environment to build for both.
-To build the dmg container for macOS, a macOS machine is required. It's suggested to use Travis-CI in this regard.
-This [documentation](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build) explains the needed dependencies to build locally.
+In order to change the JupyterLab version bundled with the App:
+
+1. Update all the dependencies in [package.json](package.json) (packages with `@jupyterlab` scope and also `@jupyter-widgets/jupyterlab-manager` for ipywidgets). Versions of `@jupyterlab` packages can be found in the commits for the release tag at https://github.com/jupyterlab/jupyterlab/releases
+
+2. Update `jupyterlab` and `ipywidgets` python package versions in [env_installer/construct.yaml](env_installer/construct.yaml)
+
+## Relase Workflow
+
+1. Create a new release on GitHub. Set the release `tag` to the value of target application version and prefix it with `v` (for example `v3.1.12-1` for JupyterLab App version `3.1.12-1`). Enter release title and release notes. Release needs to stay as `draft` or `pre-release` for GitHub Actions to be able to attach installers to the release.
+
+2. Bump application version using `tbump`. If same JupyterLab version is being bundled then only increment the build number after `-`. If JupyterLab version is incremented then reset the build number to 1.
+
+    Example: same JupyterLab version (`3.1.12`), bump from `3.1.12-2` to `3.1.12-3`
+    ```bash
+    tbump --only-patch 3.1.12-3
+    ```
+
+    Example: changing JupyterLab version (to `3.1.13`), bump from `3.1.12-3` to `3.1.13-1`
+    ```bash
+    tbump --only-patch 3.1.13-1
+    ```
+
+    tbump will list changes to be applied, confirm the changes to proceed with apply.
+
+2. Create a commit with the version changes and create a PR. The PR must be created from main repo and not from a fork. This is necessary for GitHub Actions to be able to attach installers to the release.
+
+3. GitHub Actions will automatically create installers for each platform (Linux, macOS, Windows) and upload them as release assets. Assets will be uploaded only if a release of type `draft` or `pre-release` with tag matching the JupyterLab App's version with a `v` prefix is found. For example, if the JupyterLab App version in the PR is `3.1.12-2`, the installers will be uploaded to a release that is flagged as `draft` or `pre-release` and has a tag `v3.1.12-2`. New commits to PR will overwrite the installer assets of the release.
+
+4. Once all the changes are complete, and installers are uploaded to the release then publish the release.

--- a/scripts/buildutil.js
+++ b/scripts/buildutil.js
@@ -129,8 +129,8 @@ if (cli.flags.checkVersionMatch) {
         platform === "darwin"
             ? "postinstall"
             : platform === "win32"
-                ? "electron-builder-scripts/wininstall.nsh"
-                : "electron-builder-scripts/linux_after_install.sh";
+                ? "wininstall.nsh"
+                : "linux_after_install.sh";
     const envInstallScriptPath = path.resolve(
         __dirname,
         `../electron-builder-scripts/${envInstallerScriptName}`


### PR DESCRIPTION
Updates to GitHub Actions
- Checks for version match in the App and bundled JupyterLab packages
- Uploads installer binaries to a Release if the tag match is found.
  - Release needs to have tag as `v<AppVersion>`
  - Release needs to be of type `draft` or `pre-release`
- Release documentation is updated with new instructions

For a JupyterLab version, now we can release multiple versions of JupyterLab App.

Example Release with installer assets attached [releases/tag/v3.1.12-1](https://github.com/jupyterlab/jupyterlab_app/releases/tag/v3.1.12-1)

Fixes https://github.com/jupyterlab/jupyterlab_app/issues/205