### PR TITLE
Prefer conda-forge and Miniforge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn
-          conda install -conda-forge constructor
+          conda install -c conda-forge constructor
           yarn install
 
       - name: Check JupyterLab version match

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn
-          conda install constructor
+          conda install -conda-forge constructor
           yarn install
 
       - name: Check JupyterLab version match

--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ A desktop application for [JupyterLab](https://github.com/jupyterlab/jupyterlab)
 
 ## Build dependencies
 
-
-- [conda](https://docs.conda.io/en/latest/miniconda.html)
+- [conda](https://docs.conda.io)
     
-    You can install miniconda from https://docs.conda.io/en/latest/miniconda.html
+    You can install `conda` as part of a [Miniforge](https://github.com/conda-forge/miniforge) installer.
+    
 
 - [(conda) Constructor](https://github.com/conda/constructor) to bundle JupyterLab App Server into the stand-alone application. You can install Constructor using:
 
     ```bash
-    conda install constructor
+    conda install -c conda-forge constructor
     ```
 
 - nodejs
 
     You can install from https://nodejs.org/en/download/ or run:
     ```bash
-    conda install nodejs
+    conda install -c conda-forge nodejs
     ```
 
 - yarn

--- a/env_installer/construct.yaml
+++ b/env_installer/construct.yaml
@@ -32,5 +32,4 @@ specs:
 default_prefix: "%HOMEDRIVE%\\JupyterLab\\resources\\jlab_server"
 default_prefix_all_users: "%HOMEDRIVE%\\JupyterLab\\resources\\jlab_server"
 
-license_file: ../LICENSE
 register_python_default: false

--- a/env_installer/construct.yaml
+++ b/env_installer/construct.yaml
@@ -5,19 +5,29 @@ company: "Project Jupyter"
 welcome_image_text: "JupyterLab"
 header_image_text: "JupyterLab"
 
+# see https://github.com/conda-forge/miniforge/blob/master/Miniforge3/construct.yaml
 channels:
-  - https://conda.anaconda.org/conda-forge
-  - http://repo.anaconda.com/pkgs/main/
+  # specifying the channel with the full URL adds two channels
+  # when the end user adds the channel without the full URL
+  # - https://conda.anaconda.org/conda-forge
+  - conda-forge
+
+write_condarc: True
+# keep pkgs for space-saving implications for hardlinks when create new environments
+# and keep the same with Miniconda
+keep_pkgs: True
+license_file: ../LICENSE
 
 specs:
-  - python 3.8*
   - conda
-  - numpy
-  - scipy
-  - pandas
-  - jupyterlab 3.1.12
   - ipywidgets 7.6.5
-  - matplotlib
+  - jupyterlab 3.1.12
+  - matplotlib-base
+  - numpy
+  - pandas
+  - pip
+  - python 3.8*
+  - scipy
 
 default_prefix: "%HOMEDRIVE%\\JupyterLab\\resources\\jlab_server"
 default_prefix_all_users: "%HOMEDRIVE%\\JupyterLab\\resources\\jlab_server"


### PR DESCRIPTION
## Elevator Pitch
This updates various files to prefer `conda-forge` and [miniforge](https://github.com/conda-forge/miniforge) in docs, automation, and in the shipped products.

## Motivation
- helps ensure terms of service compliance for this project and downstream users, too boring to go into in greater depth here
- normalizes the actual packages included in the installer for size and completeness

## Implementation details

Like `miniforge`, this sets `conda-forge` as the only source of packages, and writes out a `.condarc` file at install time which will prefer `conda-forge` on an on-going basis.

In further mimicking `miniforge`, this adds `pip` to `specs` (not included by default). 

It also switches to `matplotlib-base` to avoid ~200mb of `qt` (though a `qt`-based app may _well_ be interesting to investigate at some time, though that stack brings its _own_ challenges... and copy of a white-label `chromium`).