### PR TITLE
Add fullscreen mode (F11)

### DIFF
--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -88,7 +88,11 @@ class KeyboardShortcutManager implements IShortcutManager {
 
     toggleFullscreen() {
         const wasFullscreen = this._window.isFullScreen();
+        const wasMenuBarVisible = this._window.menuBarVisible;
         this._window.setFullScreen(!wasFullscreen);
+        // workaround for Electron bug https://github.com/electron/electron/issues/20237
+        // (contrary to some comments still present on Linux in Electron 10.x)
+        this._window.setMenuBarVisibility(wasMenuBarVisible);
     }
 
     zoomIn() {


### PR DESCRIPTION
Fixes #246. When leaving the full screen mode the menu bar was appearing for me which is a bug in Electron (https://github.com/electron/electron/issues/20237), which according to comments only affect Linux and was supposedly fixed in 7.0 but I still see it in 10.x. I added an innocent workaround in 12819f95f7ebd8f0f155fdb618896f1cc353ef01.